### PR TITLE
use pointers for regexp

### DIFF
--- a/driver/base/base.go
+++ b/driver/base/base.go
@@ -43,7 +43,7 @@ type Driver struct {
 	TimeoutTransport time.Duration
 	TimeoutOps       time.Duration
 
-	CommsPromptPattern regexp.Regexp
+	CommsPromptPattern *regexp.Regexp
 	CommsReturnChar    string
 
 	TransportType string
@@ -71,7 +71,7 @@ func NewDriver(
 		TimeoutSocket:      30 * time.Second,
 		TimeoutTransport:   45 * time.Second,
 		TimeoutOps:         60 * time.Second,
-		CommsPromptPattern: *regexp.MustCompile(`(?im)^[a-z0-9.\-@()/:]{1,48}[#>$]\s*$`),
+		CommsPromptPattern: regexp.MustCompile(`(?im)^[a-z0-9.\-@()/:]{1,48}[#>$]\s*$`),
 		CommsReturnChar:    "\n",
 		TransportType:      transport.SystemTransportName,
 		FailedWhenContains: []string{},
@@ -123,7 +123,7 @@ func NewDriver(
 	}
 
 	c := &channel.Channel{
-		CommsPromptPattern: &d.CommsPromptPattern,
+		CommsPromptPattern: d.CommsPromptPattern,
 		CommsReturnChar:    &d.CommsReturnChar,
 		TimeoutOps:         &d.TimeoutOps,
 		Transport:          d.Transport,

--- a/driver/base/options.go
+++ b/driver/base/options.go
@@ -130,7 +130,7 @@ func WithTimeoutOps(timeout time.Duration) Option {
 // necessary if using a network level driver.
 func WithCommsPromptPattern(pattern string) Option {
 	return func(d *Driver) error {
-		d.CommsPromptPattern = *regexp.MustCompile(pattern)
+		d.CommsPromptPattern = regexp.MustCompile(pattern)
 		return nil
 	}
 }

--- a/driver/network/network.go
+++ b/driver/network/network.go
@@ -122,12 +122,10 @@ func (d *Driver) generateJoinedCommsPromptPattern() {
 
 	joinedPattern := strings.Join(allPatterns, "|")
 
-	compiledJoinedPattern := regexp.MustCompile(joinedPattern)
-
-	d.CommsPromptPattern = *compiledJoinedPattern
+	d.CommsPromptPattern = regexp.MustCompile(joinedPattern)
 	// need to update the channel to point to the network driver's CommsPromptPattern memory addr
 	// this way if users update the driver's comms pattern, the channel is updated... there needs
 	// to be a "refreshPatterns" or something similar to scrapli for when we add dynamic priv levels
 	// for things like config sessions and such
-	d.Channel.CommsPromptPattern = &d.CommsPromptPattern
+	d.Channel.CommsPromptPattern = d.CommsPromptPattern
 }

--- a/netconf/driver.go
+++ b/netconf/driver.go
@@ -56,9 +56,9 @@ func NewNetconfDriver(
 	d.NetconfChannel = nc
 
 	// ignoring user input on comms prompt pattern too as we know what we need to look for
-	d.CommsPromptPattern = *regexp.MustCompile(Version10DelimiterPattern)
+	d.CommsPromptPattern = regexp.MustCompile(Version10DelimiterPattern)
 	// see also note in network NewNetworkDriver about similar thing...
-	d.NetconfChannel.BaseChannel.CommsPromptPattern = &d.CommsPromptPattern
+	d.NetconfChannel.BaseChannel.CommsPromptPattern = d.CommsPromptPattern
 
 	// temp for appeasing linting until they are used
 	_ = d.readableDatastores


### PR DESCRIPTION
I noticed that you used to dereference the pointer of `regexp.Regexp` that is returned by `regexp.MustCopmpile`

It seems there is no need in keeping a dereferenced value of the pointer, and we can use pointers right away 