### PR TITLE
removed fields with usable default types

### DIFF
--- a/driver/network/network.go
+++ b/driver/network/network.go
@@ -54,12 +54,10 @@ func NewNetworkDriver(
 	}
 
 	d := &Driver{
-		Driver:      *newDriver,
-		OnOpen:      onOpen,
-		OnClose:     onClose,
-		privGraph:   map[string]map[string]bool{},
-		CurrentPriv: "",
-		Augments:    map[string]func(d *Driver) (*base.Response, error){},
+		Driver:   *newDriver,
+		OnOpen:   onOpen,
+		OnClose:  onClose,
+		Augments: map[string]func(d *Driver) (*base.Response, error){},
 	}
 
 	if len(d.FailedWhenContains) == 0 {


### PR DESCRIPTION
related to #4 

we can omit the fields which default types are usable

In this PR I removed `privGraph` initialisation since it is (re)initialised in  https://github.com/scrapli/scrapligo/blob/5525033da418ac6dad09360f42d1c12871323077/driver/network/privilege.go#L17

and based in #4 it might be needed for a future work where user-defined drivers will call this func or `updateGraph` without initializing the `network.Driver` directly

Secondly, I removed `CurrentPriv: ""` as default value for the string is `""` already and it makes it redundant 