### PR TITLE
improve getPrompt  error handling

### DIFF
--- a/channel/getprompt.go
+++ b/channel/getprompt.go
@@ -55,6 +55,7 @@ func (c *Channel) GetPrompt() (string, error) {
 		if r.error != nil {
 			return "", r.error
 		}
+
 		return strings.TrimSpace(string(bytes.Trim(r.result, "\x00"))), nil
 	case <-timer.C:
 		logging.LogError(c.FormatLogMessage("error", "timed out sending getting prompt"))

--- a/channel/getprompt.go
+++ b/channel/getprompt.go
@@ -12,8 +12,7 @@ func (c *Channel) getPrompt() *channelResult {
 	err := c.SendReturn()
 	if err != nil {
 		return &channelResult{
-			result: make([]byte, 0),
-			error:  err,
+			error: err,
 		}
 	}
 
@@ -25,8 +24,7 @@ func (c *Channel) getPrompt() *channelResult {
 
 		if readErr != nil {
 			return &channelResult{
-				result: make([]byte, 0),
-				error:  readErr,
+				error: readErr,
 			}
 		}
 
@@ -54,7 +52,10 @@ func (c *Channel) GetPrompt() (string, error) {
 
 	select {
 	case r := <-_c:
-		return strings.TrimSpace(string(bytes.Trim(r.result, "\x00"))), r.error
+		if r.error != nil {
+			return "", r.error
+		}
+		return strings.TrimSpace(string(bytes.Trim(r.result, "\x00"))), nil
 	case <-timer.C:
 		logging.LogError(c.FormatLogMessage("error", "timed out sending getting prompt"))
 


### PR DESCRIPTION
If getprompt returns an error, the original code initialized a null sized byte slice and then a few Trim operations acted on this empty byte slice in the `select` statement

Maybe it will be more natural to check if the result struct contains an error and only do the Trims if there was no error?