### PR TITLE
use go-cmp to check equality in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.16
 
 require (
 	github.com/creack/pty v1.1.11
+	github.com/google/go-cmp v0.5.6
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b h1:7mWr3k41Qtv8XlltBkDkl8LoP3mpSgBW8BUoxtEdbXg=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -9,3 +11,5 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/util/testhelper/sendcommand.go
+++ b/util/testhelper/sendcommand.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/scrapli/scrapligo/driver/core"
 )
 
@@ -51,8 +52,8 @@ func SendCommandTestHelper(t *testing.T, driverName, command string) func(t *tes
 		// it for now...
 		finalResult := string(bytes.Trim([]byte(r.Result), "\x00\x0a"))
 
-		if finalResult != string(expected) {
-			t.Fatal("actual result and expected result do not match")
+		if diff := cmp.Diff(finalResult, string(expected)); diff != "" {
+			t.Errorf("actual result and expected result do not match (-want +got):\n%s", diff)
 		}
 	}
 }

--- a/util/testhelper/sendcommands.go
+++ b/util/testhelper/sendcommands.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/scrapli/scrapligo/driver/core"
 )
 
@@ -64,12 +65,12 @@ func SendCommandsTestHelper(t *testing.T, driverName string, commands []string) 
 		finalResultOne := string(bytes.Trim([]byte(responseOne), "\x00\x0a"))
 		finalResultTwo := string(bytes.Trim([]byte(responseTwo), "\x00\x0a"))
 
-		if finalResultOne != string(expectedOne) {
-			t.Fatal("actual result one and expected result do not match")
+		if diff := cmp.Diff(finalResultOne, string(expectedOne)); diff != "" {
+			t.Errorf("actual result one and expected result do not match (-want +got):\n%s", diff)
 		}
 
-		if finalResultTwo != string(expectedTwo) {
-			t.Fatal("actual result two and expected result do not match")
+		if diff := cmp.Diff(finalResultTwo, string(expectedTwo)); diff != "" {
+			t.Errorf("actual result two and expected result do not match (-want +got):\n%s", diff)
 		}
 	}
 }


### PR DESCRIPTION
to help test writers recognize the issues with the tests I propose we use go-cmp package that has a `Diff` method to show the diff between the expected and actual results:

```
=== RUN   TestSendCommands/Platform=nokia_sros
    sendcommands.go:73: actual result two and expected result do not match (-want +got):
          strings.Join({
        +       "\n",
                "================================================================",
                "===============\nInterface Table (Router: Base)\n=================",
                ... // 598 identical bytes
          }, "")
```