### PR TITLE
set echo mode for tty

### DIFF
--- a/transport/standard.go
+++ b/transport/standard.go
@@ -170,7 +170,7 @@ func (t *Standard) openBase() error {
 
 	// not sure what to do about the tty speeds... figured lets just go fast?
 	modes := ssh.TerminalModes{
-		ssh.ECHO:          0,
+		ssh.ECHO:          1,
 		ssh.TTY_OP_ISPEED: 115200,
 		ssh.TTY_OP_OSPEED: 115200,
 	}


### PR DESCRIPTION
echo mode was requested to be disabled.
this led to a case when commands were not echoed back by some ssh servers (sr linux server in `basic` mode). It seems like echoing worked before, because it was handled by the remote ssh server without paying attention to the requested pty settings.

By setting echo on, we make the commands always echoed back, as this is what scrapli needs. 


Here is a log from sr linux session where once the server goes into basic mode, it respects the required `ECHO OFF` setting and doesn't send back the input characters:

```
❯ go run private/main.go
2021/06/01 09:53:41 info::clab-scrapli-srlinux::22::opening connection to 'clab-scrapli-srlinux' on port '22'
2021/06/01 09:53:41 info::clab-scrapli-srlinux::22::connection to device opened successfully
2021/06/01 09:53:41 debug::clab-scrapli-srlinux::22::attempting to acquire privilege level: exec
2021/06/01 09:53:41 debug::clab-scrapli-srlinux::22::read: Last login: Tue Jun  1 07:49:00 2021 from 2001:172:20:20::1
2021/06/01 09:53:44 debug::clab-scrapli-srlinux::22::read: Using configuration file(s): []
Welcome to the srlinux CLI.
Type 'help' (and press <ENTER>) if you need any help using this.
2021/06/01 09:53:44 debug::clab-scrapli-srlinux::22::stripping ansi chars...
2021/06/01 09:53:44 debug::clab-scrapli-srlinux::22::read: 
2021/06/01 09:53:44 debug::clab-scrapli-srlinux::22::stripping ansi chars...
2021/06/01 09:53:44 debug::clab-scrapli-srlinux::22::read: --{ running }--[  ]--                                                                                                                                                                                                                                           
A:srlinux#                                                                                                                                                                                                                                                      
2021/06/01 09:53:44 info::clab-scrapli-srlinux::22::attempting to acquire 'exec' privilege level
2021/06/01 09:53:44 error::clab-scrapli-srlinux::22::determined current privilege level is one of: [exec]
2021/06/01 09:53:44 debug::clab-scrapli-srlinux::22::determined current privilege level is target privilege level, no action needed
2021/06/01 09:53:44 info::clab-scrapli-srlinux::22::"sending channelInput: environment cli-engine type basic; stripPrompt: true; eager: false
2021/06/01 09:53:44 debug::clab-scrapli-srlinux::22::stripping ansi chars...
2021/06/01 09:53:44 debug::clab-scrapli-srlinux::22::read: --{ running }--[  ]--                                                                                                                                                                                                                                           
A:srlinux#                                                                                                                                                                                                                                                      
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::stripping ansi chars...
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::read: 
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::stripping ansi chars...
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::read: --{ running }--[  ]--                                                                                                                                                                                                                                           
A:srlinux# environment cli-engine type basic                                                                                                                                                                                                                    
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::stripping ansi chars...
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::read: 
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::stripping ansi chars...
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::read: 
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::stripping ansi chars...
2021/06/01 09:53:45 debug::clab-scrapli-srlinux::22::read: --{ running }--[  ]--                                                                                                                                                                                                                                           
A:srlinux# environment cli-engine type basic                                                                                                                                                                                                                    
2021/06/01 09:53:46 debug::clab-scrapli-srlinux::22::read: --{ running }--[  ]--
A:srlinux# 
2021/06/01 09:53:46 debug::clab-scrapli-srlinux::22::found prompt match
2021/06/01 09:53:46 info::clab-scrapli-srlinux::22::"sending channelInput: show version; stripPrompt: true; eager: false
2021/06/01 09:53:46 debug::clab-scrapli-srlinux::22::read: --{ running }--[  ]--
A:srlinux# 
^Csignal: interrupt
```