### PR TITLE
fix byte slice allocations

### DIFF
--- a/examples/network_driver/channellog/main.go
+++ b/examples/network_driver/channellog/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	// We can then read and print out the channel log data like normal
-	b := make([]byte, 65535)
+	b := make([]byte, 0, 65535)
 	_, _ = channelLog.Read(b)
 	fmt.Printf("Channel log output:\n%s", b)
 }

--- a/transport/standard.go
+++ b/transport/standard.go
@@ -237,7 +237,7 @@ func (t *Standard) Close() error {
 }
 
 func (t *Standard) read() *transportResult {
-	b := make([]byte, ReadSize)
+	b := make([]byte, 0, ReadSize)
 	_, err := t.reader.Read(b)
 
 	if err != nil {

--- a/transport/system.go
+++ b/transport/system.go
@@ -181,7 +181,7 @@ func (t *System) Close() error {
 }
 
 func (t *System) read() *transportResult {
-	b := make([]byte, ReadSize)
+	b := make([]byte, 0, ReadSize)
 	_, err := t.sessionFd.Read(b)
 
 	if err != nil {

--- a/util/testhelper/transport.go
+++ b/util/testhelper/transport.go
@@ -35,7 +35,7 @@ func (t *TestingTransport) Read() ([]byte, error) {
 	// need to read one byte at a time so we dont auto read past prompts and commands and such
 	// its sorta strange that 65535 works for scrapli IRL but i guess its just consuming a byte at
 	// a time out of a stream rather than just reading an already present file?
-	b := make([]byte, 1)
+	b := make([]byte, 0, 1)
 	_, err := t.FakeSession.Read(b)
 
 	return b, err


### PR DESCRIPTION
```go
make([]byte, l)
```
 will produce a slice with `l` elements of 0 byte values
This is, I think, was not the intention, the intention was to init a slice with a capacity of `l` instead, for which the `make([]byte, 0, l)` should be used instead 