### PR TITLE
compile privLevels pattern only once

### DIFF
--- a/driver/base/base.go
+++ b/driver/base/base.go
@@ -15,6 +15,7 @@ import (
 // PrivilegeLevel struct defining a single privilege level -- used only for "network" level drivers.
 type PrivilegeLevel struct {
 	Pattern        string
+	PatternRe      *regexp.Regexp
 	Name           string
 	PreviousPriv   string
 	Deescalate     string

--- a/driver/network/privilege.go
+++ b/driver/network/privilege.go
@@ -19,6 +19,7 @@ func (d *Driver) buildPrivGraph() {
 	for _, privLevel := range d.PrivilegeLevels {
 		privLevel.PatternRe = regexp.MustCompile(privLevel.Pattern)
 		d.privGraph[privLevel.Name] = map[string]bool{}
+
 		if privLevel.PreviousPriv != "" {
 			d.privGraph[privLevel.Name][privLevel.PreviousPriv] = true
 		}

--- a/driver/network/privilege.go
+++ b/driver/network/privilege.go
@@ -17,6 +17,7 @@ func (d *Driver) buildPrivGraph() {
 	d.privGraph = map[string]map[string]bool{}
 
 	for _, privLevel := range d.PrivilegeLevels {
+		privLevel.PatternRe = regexp.MustCompile(privLevel.Pattern)
 		d.privGraph[privLevel.Name] = map[string]bool{}
 		if privLevel.PreviousPriv != "" {
 			d.privGraph[privLevel.Name][privLevel.PreviousPriv] = true
@@ -69,8 +70,7 @@ func (d *Driver) determineCurrentPriv(currentPrompt string) ([]string, error) {
 	var matchingPrivLevels []string
 
 	for privName, privData := range d.PrivilegeLevels {
-		privPattern := regexp.MustCompile(privData.Pattern)
-		promptMatch := privPattern.MatchString(currentPrompt)
+		promptMatch := privData.PatternRe.MatchString(currentPrompt)
 
 		if promptMatch {
 			matchingPrivLevels = append(matchingPrivLevels, privName)


### PR DESCRIPTION
@carlmontanari I wonder, if the following optimization makes sense to you

Currently we compile the `privLevel` pattern each time we acquire a priv level (or even each time we do `determineCurrentPriv()`). The optimization in this PR takes a liberty in compiling the prompt RE once during the PrivGraph build-out, so that the rest of the code can take the compiled RE right away