### PR TITLE
fix `ErrorLog -> `LogError`

### DIFF
--- a/transport/standard.go
+++ b/transport/standard.go
@@ -70,6 +70,7 @@ func (t *Standard) open(cfg *ssh.ClientConfig) error {
 		fmt.Sprintf("%s:%d", t.BaseTransportArgs.Host, t.BaseTransportArgs.Port),
 		cfg,
 	)
+
 	if err != nil {
 		logging.LogError(
 			t.FormatLogMessage("error", fmt.Sprintf("error connecting to host: %v", err)),

--- a/transport/standard.go
+++ b/transport/standard.go
@@ -65,14 +65,13 @@ func trustedHostKeyCallback(trustedKey string) ssh.HostKeyCallback {
 
 func (t *Standard) open(cfg *ssh.ClientConfig) error {
 	var err error
-
 	t.client, err = ssh.Dial(
 		"tcp",
 		fmt.Sprintf("%s:%d", t.BaseTransportArgs.Host, t.BaseTransportArgs.Port),
 		cfg,
 	)
 	if err != nil {
-		logging.ErrorLog(
+		logging.LogError(
 			t.FormatLogMessage("error", fmt.Sprintf("error connecting to host: %v", err)),
 		)
 
@@ -81,7 +80,7 @@ func (t *Standard) open(cfg *ssh.ClientConfig) error {
 
 	t.session, err = t.client.NewSession()
 	if err != nil {
-		logging.ErrorLog(
+		logging.LogError(
 			t.FormatLogMessage("error", fmt.Sprintf("error allocating session: %v", err)),
 		)
 
@@ -90,7 +89,7 @@ func (t *Standard) open(cfg *ssh.ClientConfig) error {
 
 	t.writer, err = t.session.StdinPipe()
 	if err != nil {
-		logging.ErrorLog(
+		logging.LogError(
 			t.FormatLogMessage("error", fmt.Sprintf("error allocating writer: %v", err)),
 		)
 
@@ -99,7 +98,7 @@ func (t *Standard) open(cfg *ssh.ClientConfig) error {
 
 	t.reader, err = t.session.StdoutPipe()
 	if err != nil {
-		logging.ErrorLog(
+		logging.LogError(
 			t.FormatLogMessage("error", fmt.Sprintf("error allocating reader: %v", err)),
 		)
 
@@ -128,7 +127,7 @@ func (t *Standard) openBase() error {
 		signer, err := ssh.ParsePrivateKey(key)
 
 		if err != nil {
-			logging.ErrorLog(
+			logging.LogError(
 				t.FormatLogMessage("error", fmt.Sprintf("unable to parse private key: %v", err)),
 			)
 

--- a/transport/system.go
+++ b/transport/system.go
@@ -121,7 +121,7 @@ func (t *System) Open() error {
 	)
 
 	if err != nil {
-		logging.ErrorLog(t.FormatLogMessage("error", "failed opening transport connection to host"))
+		logging.LogError(t.FormatLogMessage("error", "failed opening transport connection to host"))
 
 		return err
 	}
@@ -157,7 +157,7 @@ func (t *System) OpenNetconf() error {
 	fileObj, err := pty.Start(sshCommand)
 
 	if err != nil {
-		logging.ErrorLog(
+		logging.LogError(
 			t.FormatLogMessage("error", "failed opening netconf transport connection to host"),
 		)
 


### PR DESCRIPTION
looks like it was a typo? 

you can witness nil pointer deref in the original `main` if you use the wrong address for example