### PR TITLE
Run examples with make in DevNet always-on device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL := help
 
+NET_EXAMPLES?=examples/network_driver
+
 lint: ## Run linters
 	gofmt -w -s .
 	goimports -w .
@@ -13,22 +15,22 @@ base-example: ## Run Base example
 	-@go run examples/base_driver/main.go
 
 net-simple-example: ## Run Network simple example
-	-@go run examples/network_driver/simple/main.go -argument=examples/network_driver/simple/commandsfile
+	-@go run ${NET_EXAMPLES}/simple/main.go -argument=${NET_EXAMPLES}/simple/commandsfile
 
 net-log-example: ## Run Network logging example
-	-@go run examples/network_driver/logging/main.go
+	-@go run ${NET_EXAMPLES}/logging/main.go
 
 net-interactive-example: ## Run Network Interactive example
-	-@go run examples/network_driver/interactive/main.go
+	-@go run ${NET_EXAMPLES}/interactive/main.go
 
 net-factory-example: ## Run Network Factory example
-	-@go run examples/network_driver/factory/main.go
+	-@go run ${NET_EXAMPLES}/factory/main.go
 
 net-onopen-example: ## Run Network On Open example
-	-@go run examples/network_driver/custom_onopen/main.go
+	-@go run ${NET_EXAMPLES}/custom_onopen/main.go
 
 net-channellog-example: ## Run Network Channel Log example
-	-@go run examples/network_driver/channellog/main.go
+	-@go run ${NET_EXAMPLES}/channellog/main.go
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .DEFAULT_GOAL := help
 
-NET_EXAMPLES?=examples/network_driver
-
 lint: ## Run linters
 	gofmt -w -s .
 	goimports -w .
@@ -10,30 +8,6 @@ lint: ## Run linters
 
 test: ## Test execution
 	go test -cover -v ./channel/... ./driver/... ./netconf/... ./logging/... ./transport/...
-
-examples: base-example net-simple-example net-log-example net-interactive-example net-factory-example \
-          net-onopen-example net-channellog-example
-
-base-example: ## Run Base example
-	-@go run examples/base_driver/main.go
-
-net-simple-example: ## Run Network simple example
-	-@go run ${NET_EXAMPLES}/simple/main.go -argument=${NET_EXAMPLES}/simple/commandsfile
-
-net-log-example: ## Run Network logging example
-	-@go run ${NET_EXAMPLES}/logging/main.go
-
-net-interactive-example: ## Run Network Interactive example
-	-@go run ${NET_EXAMPLES}/interactive/main.go
-
-net-factory-example: ## Run Network Factory example
-	-@go run ${NET_EXAMPLES}/factory/main.go
-
-net-onopen-example: ## Run Network On Open example
-	-@go run ${NET_EXAMPLES}/custom_onopen/main.go
-
-net-channellog-example: ## Run Network Channel Log example
-	-@go run ${NET_EXAMPLES}/channellog/main.go
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ lint: ## Run linters
 test: ## Test execution
 	go test -cover -v ./channel/... ./driver/... ./netconf/... ./logging/... ./transport/...
 
+examples: base-example net-simple-example net-log-example net-interactive-example net-factory-example \
+          net-onopen-example net-channellog-example
+
 base-example: ## Run Base example
 	-@go run examples/base_driver/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,34 @@
-lint:
+.DEFAULT_GOAL := help
+
+lint: ## Run linters
 	gofmt -w -s .
 	goimports -w .
 	golines -w .
 	golangci-lint run
 
-test:
+test: ## Test execution
 	go test -cover -v ./channel/... ./driver/... ./netconf/... ./logging/... ./transport/...
+
+base-example: ## Run Base example
+	-@go run examples/base_driver/main.go
+
+net-simple-example: ## Run Network simple example
+	-@go run examples/network_driver/simple/main.go -argument=examples/network_driver/simple/commandsfile
+
+net-log-example: ## Run Network logging example
+	-@go run examples/network_driver/logging/main.go
+
+net-interactive-example: ## Run Network Interactive example
+	-@go run examples/network_driver/interactive/main.go
+
+net-factory-example: ## Run Network Factory example
+	-@go run examples/network_driver/factory/main.go
+
+net-onopen-example: ## Run Network On Open example
+	-@go run examples/network_driver/custom_onopen/main.go
+
+net-channellog-example: ## Run Network Channel Log example
+	-@go run examples/network_driver/channellog/main.go
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -21,14 +21,32 @@ scrapligo -- scrap(e c)li (but in go!) --  is a Go library focused on connecting
 #### Key Features:
 
 - __Easy__: It's easy to get going with scrapligo -- if you are familiar with go and/or scrapli you are already most of 
-  the way there! Check otu the examples linked above to get started! 
+  the way there! Check out the examples linked above to get started! 
 - __Fast__: Do you like to go fast? Of course you do! All of scrapli is built with speed in mind, but this port of 
   scrapli to go is of course even faster than its python sibling! 
 - __But wait, there's more!__: Have NETCONF devices in your environment, but love the speed and simplicity of
   scrapli? You're in luck! NETCONF support is built right into scrapligo!
 
+## Running examples
 
-## A simple Example
+You need Go 1.16+ installed. Clone the the repo and  run `make` to see the list. 
+
+```bash
+$  make net-simple-example 
+found prompt: 
+csr1000v-1#
+
+
+sent command 'show version', output received:
+ Cisco IOS XE Software, Version 16.09.03
+Cisco IOS Software [Fuji], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.9.3, RELEASE SOFTWARE (fc2)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2019 by Cisco Systems, Inc.
+Compiled Wed 20-Mar-19 07:56 by mcpre
+...
+```
+
+## Code Example
 
 ```go
 package main
@@ -37,7 +55,6 @@ import (
 	"fmt"
 
 	"github.com/scrapli/scrapligo/driver/base"
-
 	"github.com/scrapli/scrapligo/driver/core"
 )
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ scrapligo -- scrap(e c)li (but in go!) --  is a Go library focused on connecting
 - __But wait, there's more!__: Have NETCONF devices in your environment, but love the speed and simplicity of
   scrapli? You're in luck! NETCONF support is built right into scrapligo!
 
-## Running examples
+## Running the examples
 
-You need Go 1.16+ installed. Clone the the repo and  run `make` to see the list. 
+You need [Go 1.16+](https://golang.org/doc/install) installed. Clone the the repo and ``go run` any of the examples in the (examples)[examples] folder. 
 
 ```bash
-$  make net-simple-example 
+$  go run examples/base_driver/main.go
 found prompt: 
 csr1000v-1#
 

--- a/examples/base_driver/main.go
+++ b/examples/base_driver/main.go
@@ -4,17 +4,16 @@ import (
 	"fmt"
 
 	"github.com/scrapli/scrapligo/channel"
-
 	"github.com/scrapli/scrapligo/driver/base"
 )
 
 func main() {
 	d, err := base.NewDriver(
-		"localhost",
-		base.WithPort(21022),
+		"ios-xe-mgmt.cisco.com",
+		base.WithPort(8181),
 		base.WithAuthStrictKey(false),
-		base.WithAuthUsername("vrnetlab"),
-		base.WithAuthPassword("VR-netlab9"),
+		base.WithAuthUsername("developer"),
+		base.WithAuthPassword("C1sco12345"),
 	)
 
 	if err != nil {
@@ -31,7 +30,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to get prompt; error: %+v\n", err)
 	} else {
-		fmt.Printf("found prompt: %s\n", prompt)
+		fmt.Printf("found prompt: %s\n\n\n", prompt)
 	}
 
 	// send some input
@@ -41,7 +40,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to send input to device; error: %+v\n", err)
 	} else {
-		fmt.Printf("output received: %s\n", output)
+		fmt.Printf("output received (SendInput):\n %s\n\n\n", output)
 	}
 
 	// send an interactive input
@@ -64,7 +63,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to send interactive input to device; error: %+v\n", err)
 	} else {
-		fmt.Printf("output received: %s\n", interactiveOutput)
+		fmt.Printf("output received (SendInteractive):\n %s\n\n\n", interactiveOutput)
 	}
 
 	// send a command -- as this is "base" there will have been no paging disabling, so have to
@@ -75,7 +74,11 @@ func main() {
 		fmt.Printf("failed to send command; error: %+v\n", err)
 		return
 	}
-	fmt.Printf("sent command '%s', output received:\n %s\n", r.ChannelInput, r.Result)
+	fmt.Printf(
+		"sent command '%s', output received (SendCommand):\n %s\n\n\n",
+		r.ChannelInput,
+		r.Result,
+	)
 
 	err = d.Close()
 	if err != nil {

--- a/examples/netconf/main.go
+++ b/examples/netconf/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/scrapli/scrapligo/driver/base"
-
 	"github.com/scrapli/scrapligo/netconf"
 )
 

--- a/examples/network_driver/channellog/main.go
+++ b/examples/network_driver/channellog/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/scrapli/scrapligo/driver/base"
-
 	"github.com/scrapli/scrapligo/driver/core"
 )
 
@@ -15,13 +14,12 @@ func main() {
 
 	// use the NewCoreDriver factory and pass in a platform argument
 	d, err := core.NewCoreDriver(
-		"localhost",
+		"ios-xe-mgmt.cisco.com",
 		"cisco_iosxe",
-		base.WithPort(21022),
+		base.WithPort(8181),
 		base.WithAuthStrictKey(false),
-		base.WithAuthUsername("vrnetlab"),
-		base.WithAuthPassword("VR-netlab9"),
-		base.WithAuthSecondary("VR-netlab9"),
+		base.WithAuthUsername("developer"),
+		base.WithAuthPassword("C1sco12345"),
 		base.WithChannelLog(&channelLog),
 	)
 
@@ -41,7 +39,7 @@ func main() {
 		fmt.Printf("failed to get prompt; error: %+v\n", err)
 		return
 	}
-	fmt.Printf("found prompt: %s\n", prompt)
+	fmt.Printf("found prompt: %s\n\n\n", prompt)
 
 	err = d.Close()
 	if err != nil {

--- a/examples/network_driver/custom_onopen/main.go
+++ b/examples/network_driver/custom_onopen/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/scrapli/scrapligo/driver/base"
-
 	"github.com/scrapli/scrapligo/driver/core"
 	"github.com/scrapli/scrapligo/driver/network"
 )
@@ -30,13 +29,12 @@ func customOnOpen(d *network.Driver) error {
 
 func main() {
 	d, err := core.NewCoreDriver(
-		"localhost",
+		"ios-xe-mgmt.cisco.com",
 		"cisco_iosxe",
-		base.WithPort(21022),
+		base.WithPort(8181),
 		base.WithAuthStrictKey(false),
-		base.WithAuthUsername("vrnetlab"),
-		base.WithAuthPassword("VR-netlab9"),
-		base.WithAuthSecondary("VR-netlab9"),
+		base.WithAuthUsername("developer"),
+		base.WithAuthPassword("C1sco12345"),
 	)
 
 	if err != nil {
@@ -61,7 +59,7 @@ func main() {
 		fmt.Printf("failed to get prompt; error: %+v\n", err)
 		return
 	}
-	fmt.Printf("found prompt: %s\n", prompt)
+	fmt.Printf("found prompt: %s\n\n\n", prompt)
 
 	err = d.Close()
 	if err != nil {

--- a/examples/network_driver/factory/main.go
+++ b/examples/network_driver/factory/main.go
@@ -4,20 +4,18 @@ import (
 	"fmt"
 
 	"github.com/scrapli/scrapligo/driver/base"
-
 	"github.com/scrapli/scrapligo/driver/core"
 )
 
 func main() {
 	// use the NewCoreDriver factory and pass in a platform argument
 	d, err := core.NewCoreDriver(
-		"localhost",
+		"ios-xe-mgmt.cisco.com",
 		"cisco_iosxe",
-		base.WithPort(21022),
+		base.WithPort(8181),
 		base.WithAuthStrictKey(false),
-		base.WithAuthUsername("vrnetlab"),
-		base.WithAuthPassword("VR-netlab9"),
-		base.WithAuthSecondary("VR-netlab9"),
+		base.WithAuthUsername("developer"),
+		base.WithAuthPassword("C1sco12345"),
 	)
 
 	if err != nil {
@@ -36,7 +34,7 @@ func main() {
 		fmt.Printf("failed to get prompt; error: %+v\n", err)
 		return
 	}
-	fmt.Printf("found prompt: %s\n", prompt)
+	fmt.Printf("found prompt: %s\n\n\n", prompt)
 
 	err = d.Close()
 	if err != nil {

--- a/examples/network_driver/interactive/main.go
+++ b/examples/network_driver/interactive/main.go
@@ -4,22 +4,19 @@ import (
 	"fmt"
 
 	"github.com/scrapli/scrapligo/channel"
-
 	"github.com/scrapli/scrapligo/driver/base"
-
 	"github.com/scrapli/scrapligo/driver/core"
 )
 
 func main() {
 	// use the NewCoreDriver factory and pass in a platform argument
 	d, err := core.NewCoreDriver(
-		"localhost",
+		"ios-xe-mgmt.cisco.com",
 		"cisco_iosxe",
-		base.WithPort(21022),
+		base.WithPort(8181),
 		base.WithAuthStrictKey(false),
-		base.WithAuthUsername("vrnetlab"),
-		base.WithAuthPassword("VR-netlab9"),
-		base.WithAuthSecondary("VR-netlab9"),
+		base.WithAuthUsername("developer"),
+		base.WithAuthPassword("C1sco12345"),
 	)
 
 	if err != nil {

--- a/examples/network_driver/logging/main.go
+++ b/examples/network_driver/logging/main.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/scrapli/scrapligo/logging"
-
 	"github.com/scrapli/scrapligo/driver/base"
-
 	"github.com/scrapli/scrapligo/driver/core"
+	"github.com/scrapli/scrapligo/logging"
 )
 
 func main() {
@@ -19,13 +17,12 @@ func main() {
 
 	// use the NewCoreDriver factory and pass in a platform argument
 	d, err := core.NewCoreDriver(
-		"localhost",
+		"ios-xe-mgmt.cisco.com",
 		"cisco_iosxe",
-		base.WithPort(21022),
+		base.WithPort(8181),
 		base.WithAuthStrictKey(false),
-		base.WithAuthUsername("vrnetlab"),
-		base.WithAuthPassword("VR-netlab9"),
-		base.WithAuthSecondary("VR-netlab9"),
+		base.WithAuthUsername("developer"),
+		base.WithAuthPassword("C1sco12345"),
 	)
 
 	if err != nil {
@@ -44,7 +41,7 @@ func main() {
 		fmt.Printf("failed to get prompt; error: %+v\n", err)
 		return
 	}
-	fmt.Printf("found prompt: %s\n", prompt)
+	fmt.Printf("found prompt: %s\n\n\n", prompt)
 
 	err = d.Close()
 	if err != nil {

--- a/examples/network_driver/simple/main.go
+++ b/examples/network_driver/simple/main.go
@@ -11,7 +11,7 @@ import (
 // const commandsFile = "commandsfile"
 
 func main() {
-	arg := flag.String("argument", "", "argument from Makefile")
+	arg := flag.String("file", "examples/simple/commandsfile", "argument from user")
 	flag.Parse()
 
 	d, err := core.NewCoreDriver(

--- a/examples/network_driver/simple/main.go
+++ b/examples/network_driver/simple/main.go
@@ -1,24 +1,26 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 
 	"github.com/scrapli/scrapligo/driver/base"
-
 	"github.com/scrapli/scrapligo/driver/core"
 )
 
-const commandsFile = "commandsfile"
+// const commandsFile = "commandsfile"
 
 func main() {
+	arg := flag.String("argument", "", "argument from Makefile")
+	flag.Parse()
+
 	d, err := core.NewCoreDriver(
-		"localhost",
+		"ios-xe-mgmt.cisco.com",
 		"cisco_iosxe",
-		base.WithPort(21022),
+		base.WithPort(8181),
 		base.WithAuthStrictKey(false),
-		base.WithAuthUsername("vrnetlab"),
-		base.WithAuthPassword("VR-netlab9"),
-		base.WithAuthSecondary("VR-netlab9"),
+		base.WithAuthUsername("developer"),
+		base.WithAuthPassword("C1sco12345"),
 	)
 
 	if err != nil {
@@ -37,17 +39,17 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to get prompt; error: %+v\n", err)
 	} else {
-		fmt.Printf("found prompt: %s\n", prompt)
+		fmt.Printf("found prompt: %s\n\n\n", prompt)
 	}
 
 	// send some commands from a file
-	mr, err := d.SendCommandsFromFile(commandsFile)
+	mr, err := d.SendCommandsFromFile(*arg)
 	if err != nil {
 		fmt.Printf("failed to send commands from file; error: %+v\n", err)
 		return
 	}
 	for _, r := range mr.Responses {
-		fmt.Printf("sent command '%s', output received:\n %s\n", r.ChannelInput, r.Result)
+		fmt.Printf("sent command '%s', output received:\n %s\n\n\n", r.ChannelInput, r.Result)
 	}
 
 	// send some configs


### PR DESCRIPTION
What do you think if the examples run against the DevNet always-on IOS-XE device, so anyone can run the examples?

I also added them to the Make file, so you can execute them from the root (all but the NETCONF one)

```bash
$ make
base-example                   Run Base example
lint                           Run linters
net-channellog-example         Run Network Channel Log example
net-factory-example            Run Network Factory example
net-interactive-example        Run Network Interactive example
net-log-example                Run Network logging example
net-onopen-example             Run Network On Open example
net-simple-example             Run Network simple example
test                           Test execution
```

I added a note in the readme on how you would run the examples.

```bash
$  make net-simple-example 
found prompt: 
csr1000v-1#


sent command 'show version', output received:
 Cisco IOS XE Software, Version 16.09.03
Cisco IOS Software [Fuji], Virtual XE Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.9.3, RELEASE SOFTWARE (fc2)
Technical Support: http://www.cisco.com/techsupport
Copyright (c) 1986-2019 by Cisco Systems, Inc.
Compiled Wed 20-Mar-19 07:56 by mcpre
...
```

PS: I added a bit more space between the outputs to make it more clear. 