### PR TITLE
Add TextFSM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ scrapligo -- scrap(e c)li (but in go!) --  is a Go library focused on connecting
 
 You need [Go 1.16+](https://golang.org/doc/install) installed. Clone the repo and `go run` any of the examples in the [examples](/examples) folder. 
 
+### Executing a number of commands (from a file)
+
 ```bash
 $  go run examples/base_driver/main.go
 found prompt: 
@@ -44,6 +46,17 @@ Technical Support: http://www.cisco.com/techsupport
 Copyright (c) 1986-2019 by Cisco Systems, Inc.
 Compiled Wed 20-Mar-19 07:56 by mcpre
 ...
+```
+
+### Parsing a command output
+
+For more details, check out [Network automation options in Go with scrapligo](https://netdevops.me/2021/network-automation-options-in-go-with-scrapligo/).
+
+```yaml
+$  go run examples/network_driver/textfsm/main.go
+Hostname: csr1000v-1
+SW Version: 16.9.3
+Uptime: 18 minutes
 ```
 
 ## Code Example

--- a/examples/network_driver/textfsm/cisco_ios_show_version.textfsm
+++ b/examples/network_driver/textfsm/cisco_ios_show_version.textfsm
@@ -1,0 +1,32 @@
+Value VERSION (.+?)
+Value ROMMON (\S+)
+Value HOSTNAME (\S+)
+Value UPTIME (.+)
+Value RELOAD_REASON (.+?)
+Value RUNNING_IMAGE (\S+)
+Value List HARDWARE (\S+|\S+\d\S+)
+Value List SERIAL (\S+)
+Value CONFIG_REGISTER (\S+)
+Value List MAC ([0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5})
+
+Start
+  ^.*Software\s.+\),\sVersion\s${VERSION},*\s+RELEASE.*
+  ^ROM:\s+${ROMMON}
+  ^\s*${HOSTNAME}\s+uptime\s+is\s+${UPTIME}
+  ^[sS]ystem\s+image\s+file\s+is\s+"(.*?):${RUNNING_IMAGE}"
+  ^(?:[lL]ast\s+reload\s+reason:|System\s+returned\s+to\s+ROM\s+by)\s+${RELOAD_REASON}\s*$$
+  ^[Pp]rocessor\s+board\s+ID\s+${SERIAL}
+  ^[Cc]isco\s+${HARDWARE}\s+\(.+\).+
+  ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}
+  ^Base\s+[Ee]thernet\s+MAC\s+[Aa]ddress\s+:\s+${MAC}
+  ^Switch\s+Port -> Stack
+  # Capture time-stamp if vty line has command time-stamping turned on
+  ^Load\s+for\s+
+  ^Time\s+source\s+is
+
+
+Stack
+  ^[Ss]ystem\s+[Ss]erial\s+[Nn]umber\s+:\s+${SERIAL}
+  ^[Mm]odel\s+[Nn]umber\s+:\s+${HARDWARE}\s*
+  ^[Cc]onfiguration\s+register\s+is\s+${CONFIG_REGISTER}
+  ^Base [Ee]thernet MAC [Aa]ddress\s+:\s+${MAC}

--- a/examples/network_driver/textfsm/main.go
+++ b/examples/network_driver/textfsm/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/scrapli/scrapligo/driver/base"
+	"github.com/scrapli/scrapligo/driver/core"
+)
+
+func main() {
+	// File from https://github.com/networktocode/ntc-templates/blob/master/ntc_templates/templates/cisco_ios_show_version.textfsm
+	arg := flag.String("file", "examples/network_driver/textfsm/cisco_ios_show_version.textfsm", "argument from user")
+	flag.Parse()
+
+	d, err := core.NewCoreDriver(
+		"ios-xe-mgmt.cisco.com",
+		"cisco_iosxe",
+		base.WithPort(8181),
+		base.WithAuthStrictKey(false),
+		base.WithAuthUsername("developer"),
+		base.WithAuthPassword("C1sco12345"),
+	)
+
+	if err != nil {
+		fmt.Printf("failed to create driver; error: %+v\n", err)
+		return
+	}
+
+	err = d.Open()
+	if err != nil {
+		fmt.Printf("failed to open driver; error: %+v\n", err)
+		return
+	}
+	defer d.Close()
+
+	r, err := d.SendCommand("show version")
+	if err != nil {
+		fmt.Printf("failed to send command; error: %+v\n", err)
+		return
+	}
+
+	parsedOut, err := r.TextFsmParse(*arg)
+	if err != nil {
+		fmt.Printf("failed to parse command; error: %+v\n", err)
+		return
+	}
+
+	fmt.Printf("Hostname: %s\nSW Version: %s\nUptime: %s\n",
+		parsedOut[0]["HOSTNAME"], parsedOut[0]["VERSION"], parsedOut[0]["UPTIME"])
+
+}


### PR DESCRIPTION
That. Based on @hellt [blog post](https://netdevops.me/2021/network-automation-options-in-go-with-scrapligo/). I added it to the readme as well, as this example is appealing to network engineers.

Also, notice I use defer to close the driver, which I think we should do in all examples. 