### PR TITLE
Add defer to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ func main() {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 		return
 	}
+	defer d.Close()
 
 	// send some configs
 	configs := []string{
@@ -104,11 +105,6 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to send configs; error: %+v\n", err)
 		return
-	}
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("failed to close driver; error: %+v\n", err)
 	}
 }
 ```

--- a/examples/base_driver/main.go
+++ b/examples/base_driver/main.go
@@ -24,6 +24,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 	}
+	defer d.Close()
 
 	// fetch the prompt
 	prompt, err := d.Channel.GetPrompt()
@@ -79,9 +80,4 @@ func main() {
 		r.ChannelInput,
 		r.Result,
 	)
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("failed to close driver; error: %+v\n", err)
-	}
 }

--- a/examples/netconf/main.go
+++ b/examples/netconf/main.go
@@ -22,6 +22,7 @@ func main() {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 		return
 	}
+	defer d.Close()
 
 	r, err := d.GetConfig("running")
 	if err != nil {
@@ -65,9 +66,4 @@ func main() {
 	fmt.Printf("Edit Config Response: %s\n", r.Result)
 
 	_, _ = d.Commit()
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("some issue closing driver -> %v\n", err)
-	}
 }

--- a/examples/network_driver/channellog/main.go
+++ b/examples/network_driver/channellog/main.go
@@ -33,6 +33,7 @@ func main() {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 		return
 	}
+	defer d.Close()
 
 	prompt, err := d.GetPrompt()
 	if err != nil {
@@ -40,11 +41,6 @@ func main() {
 		return
 	}
 	fmt.Printf("found prompt: %s\n\n\n", prompt)
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("failed to close driver; error: %+v\n", err)
-	}
 
 	// We can then read and print out the channel log data like normal
 	b := make([]byte, 65535)

--- a/examples/network_driver/custom_onopen/main.go
+++ b/examples/network_driver/custom_onopen/main.go
@@ -53,6 +53,7 @@ func main() {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 		return
 	}
+	defer d.Close()
 
 	prompt, err := d.GetPrompt()
 	if err != nil {
@@ -60,9 +61,4 @@ func main() {
 		return
 	}
 	fmt.Printf("found prompt: %s\n\n\n", prompt)
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("failed to close driver; error: %+v\n", err)
-	}
 }

--- a/examples/network_driver/factory/main.go
+++ b/examples/network_driver/factory/main.go
@@ -28,6 +28,7 @@ func main() {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 		return
 	}
+	defer d.Close()
 
 	prompt, err := d.GetPrompt()
 	if err != nil {
@@ -35,9 +36,4 @@ func main() {
 		return
 	}
 	fmt.Printf("found prompt: %s\n\n\n", prompt)
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("failed to close driver; error: %+v\n", err)
-	}
 }

--- a/examples/network_driver/interactive/main.go
+++ b/examples/network_driver/interactive/main.go
@@ -29,6 +29,7 @@ func main() {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 		return
 	}
+	defer d.Close()
 
 	events := []*channel.SendInteractiveEvent{
 		{
@@ -49,9 +50,4 @@ func main() {
 		return
 	}
 	fmt.Printf("interact response:\n%s\n", r.Result)
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("failed to close driver; error: %+v\n", err)
-	}
 }

--- a/examples/network_driver/logging/main.go
+++ b/examples/network_driver/logging/main.go
@@ -35,6 +35,7 @@ func main() {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 		return
 	}
+	defer d.Close()
 
 	prompt, err := d.GetPrompt()
 	if err != nil {
@@ -42,9 +43,4 @@ func main() {
 		return
 	}
 	fmt.Printf("found prompt: %s\n\n\n", prompt)
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("failed to close driver; error: %+v\n", err)
-	}
 }

--- a/examples/network_driver/simple/main.go
+++ b/examples/network_driver/simple/main.go
@@ -33,6 +33,7 @@ func main() {
 		fmt.Printf("failed to open driver; error: %+v\n", err)
 		return
 	}
+	defer d.Close()
 
 	// fetch the prompt
 	prompt, err := d.GetPrompt()
@@ -63,10 +64,5 @@ func main() {
 	if err != nil {
 		fmt.Printf("failed to send configs; error: %+v\n", err)
 		return
-	}
-
-	err = d.Close()
-	if err != nil {
-		fmt.Printf("failed to close driver; error: %+v\n", err)
 	}
 }

--- a/examples/network_driver/textfsm/main.go
+++ b/examples/network_driver/textfsm/main.go
@@ -10,7 +10,11 @@ import (
 
 func main() {
 	// File from https://github.com/networktocode/ntc-templates/blob/master/ntc_templates/templates/cisco_ios_show_version.textfsm
-	arg := flag.String("file", "examples/network_driver/textfsm/cisco_ios_show_version.textfsm", "argument from user")
+	arg := flag.String(
+		"file",
+		"examples/network_driver/textfsm/cisco_ios_show_version.textfsm",
+		"argument from user",
+	)
 	flag.Parse()
 
 	d, err := core.NewCoreDriver(
@@ -48,5 +52,4 @@ func main() {
 
 	fmt.Printf("Hostname: %s\nSW Version: %s\nUptime: %s\n",
 		parsedOut[0]["HOSTNAME"], parsedOut[0]["VERSION"], parsedOut[0]["UPTIME"])
-
 }


### PR DESCRIPTION
 I added a `defer` statement to every example, otherwise, they could return without actually closing the driver.