### PR TITLE
added copy-config support

### DIFF
--- a/netconf/copyconfig.go
+++ b/netconf/copyconfig.go
@@ -1,0 +1,8 @@
+package netconf
+
+// CopyConfig issues copy-config rpc to device.
+func (d *Driver) CopyConfig(source, target string) (*Response, error) {
+	netconfMessage := d.BuildCopyConfigElem(source, target)
+
+	return d.finalizeAndSendMessage(netconfMessage)
+}

--- a/netconf/payload.go
+++ b/netconf/payload.go
@@ -278,7 +278,7 @@ type CopyConfig struct {
 	Target  *Target  `xml:""`
 }
 
-// BuildDeleteConfigElem creates a delete-config element for a get operation.
+// BuildCopyConfigElem creates a copy-config element for a copy-config operation.
 func (d *Driver) BuildCopyConfigElem(
 	source,
 	target string,

--- a/netconf/payload.go
+++ b/netconf/payload.go
@@ -269,6 +269,31 @@ func (d *Driver) BuildDeleteConfigElem(
 	return netconfInput
 }
 
+// copy-config
+
+// CopyConfig struct representing the copy-config message element.
+type CopyConfig struct {
+	XMLName xml.Name `xml:"copy-config"`
+	Source  *Source  `xml:""`
+	Target  *Target  `xml:""`
+}
+
+// BuildDeleteConfigElem creates a delete-config element for a get operation.
+func (d *Driver) BuildCopyConfigElem(
+	source,
+	target string,
+) *Message {
+	copyConfigElem := &CopyConfig{
+		XMLName: xml.Name{},
+		Source:  d.BuildSourceElem(source),
+		Target:  d.BuildTargetElem(target),
+	}
+
+	netconfInput := d.BuildPayload(copyConfigElem)
+
+	return netconfInput
+}
+
 // commit
 
 // Commit struct representing the commit message element.


### PR DESCRIPTION
making scrapligo-netconf more feature rich

example:

```go
package main

import (
	"fmt"
	"log"

	"github.com/scrapli/scrapligo/driver/base"
	"github.com/scrapli/scrapligo/netconf"
	"github.com/scrapli/scrapligo/transport"
)

func main() {
	d, err := netconf.NewNetconfDriver(
		"clab-sros01-sr1",
		base.WithAuthStrictKey(false),
		base.WithAuthUsername("admin"),
		base.WithAuthPassword("admin"),
		base.WithTransportType(transport.StandardTransportName),
	)
	if err != nil {
		log.Fatal(err)
	}

	err = d.Open()
	if err != nil {
		log.Fatal(err)
	}
	defer d.Close()

	r, err := d.CopyConfig("running", "startup")
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println(r.Result)

}

```

output:
```
 go run private/main_netconf3.go

<rpc-reply message-id="101" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
    <ok/>
</rpc-reply>
```