### PR TITLE
fix nc capabilities re to allow for namespaced tags

### DIFF
--- a/netconf/capabilities.go
+++ b/netconf/capabilities.go
@@ -43,7 +43,7 @@ func (c *Channel) parseServerCapabilities(authenticationBuf []byte) error {
 	}
 
 	// rather than deal w/ xml like scrapli python does, just regex the caps out
-	serverCapabilitiesPattern := regexp.MustCompile(`(?i)(?:<capability>)(.*?)(?:</capability>)`)
+	serverCapabilitiesPattern := regexp.MustCompile(`(?i)(?:<\w+:capability>)(.*?)(?:<\/\w+:capability>)`)
 	serverCapabilitiesMatches := serverCapabilitiesPattern.FindAllSubmatch(authenticationBuf, -1)
 
 	serverCapabilities := make([]string, 1)

--- a/netconf/capabilities.go
+++ b/netconf/capabilities.go
@@ -43,7 +43,7 @@ func (c *Channel) parseServerCapabilities(authenticationBuf []byte) error {
 	}
 
 	// rather than deal w/ xml like scrapli python does, just regex the caps out
-	serverCapabilitiesPattern := regexp.MustCompile(`(?i)(?:<\w+:capability>)(.*?)(?:<\/\w+:capability>)`)
+	serverCapabilitiesPattern := regexp.MustCompile(`(?i)(?:<\w+:capability>)(.*?)(?:</\w+:capability>)`)
 	serverCapabilitiesMatches := serverCapabilitiesPattern.FindAllSubmatch(authenticationBuf, -1)
 
 	serverCapabilities := make([]string, 1)

--- a/netconf/capabilities.go
+++ b/netconf/capabilities.go
@@ -43,7 +43,9 @@ func (c *Channel) parseServerCapabilities(authenticationBuf []byte) error {
 	}
 
 	// rather than deal w/ xml like scrapli python does, just regex the caps out
-	serverCapabilitiesPattern := regexp.MustCompile(`(?i)(?:<\w+:capability>)(.*?)(?:</\w+:capability>)`)
+	serverCapabilitiesPattern := regexp.MustCompile(
+		`(?i)(?:<(?:\w+:)?capability>)(.*?)(?:</(?:\w+:)?capability>)`
+	)
 	serverCapabilitiesMatches := serverCapabilitiesPattern.FindAllSubmatch(authenticationBuf, -1)
 
 	serverCapabilities := make([]string, 1)

--- a/netconf/capabilities.go
+++ b/netconf/capabilities.go
@@ -44,7 +44,7 @@ func (c *Channel) parseServerCapabilities(authenticationBuf []byte) error {
 
 	// rather than deal w/ xml like scrapli python does, just regex the caps out
 	serverCapabilitiesPattern := regexp.MustCompile(
-		`(?i)(?:<(?:\w+:)?capability>)(.*?)(?:</(?:\w+:)?capability>)`
+		`(?i)(?:<(?:\w+:)?capability>)(.*?)(?:</(?:\w+:)?capability>)`,
 	)
 	serverCapabilitiesMatches := serverCapabilitiesPattern.FindAllSubmatch(authenticationBuf, -1)
 


### PR DESCRIPTION
Junos uses namespaced tags in their hellos. this caused no matches for capabilities in scrapligo

the following re allows namespaced tags as shown here https://regex101.com/r/w1M6Lp/1

