### PR TITLE
junos: fixes config push via scraplitest

### DIFF
--- a/cfg/options.go
+++ b/cfg/options.go
@@ -141,6 +141,23 @@ func WithFilesystem(fs string) Option {
 	}
 }
 
+// WithCandidateConfigFilename set the default candidate config filename
+// for your platform. Better to use only in the testing env where a
+// definite constant filename of config file on the device is helpful.
+func WithCandidateConfigFilename(fn string) Option {
+	return func(p interface{}) error {
+		err := setPlatformAttr("CandidateConfigFilename", fn, p)
+
+		if err != nil {
+			if !errors.Is(err, ErrIgnoredOption) {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
 // operation specific options
 
 // OperationOptions struct for options for any "operation" (LoadConfig, CommitConfig, etc.).


### PR DESCRIPTION
While using NewCfgDriver, LoadConfig() creates a file on the device and
pushes config to it. By default scrapligo creates a file with time
embedded to the file name. This makes sure the file name is unique but
creates issues in the testing env while using PatchedTrasport.

Transport pushes a line to the device and expects to read back the same
line but in testing env it is not possible as the temp config file name
is not known in advance. This change makes sure one can pass a custom
filename for a file to be created (pretend) on the device. It can also
be used in non test env but might cause issues if file with the same
name already exists.

Capitalized the struct filed to make it exportable to other packages.