### PR TITLE
Compile patterns once

### DIFF
--- a/cfg/aristaeos.go
+++ b/cfg/aristaeos.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/scrapli/scrapligo/logging"
@@ -18,16 +19,19 @@ type eosPatterns struct {
 	endPattern               *regexp.Regexp
 }
 
-var eosPatternsInstance *eosPatterns //nolint:gochecknoglobals
+var (
+	eosPatternsInstance     *eosPatterns //nolint:gochecknoglobals
+	eosPAtternsInstanceOnce sync.Once    //nolint:gochecknoglobals
+)
 
 func getEOSPatterns() *eosPatterns {
-	if eosPatternsInstance == nil {
+	eosPAtternsInstanceOnce.Do(func() {
 		eosPatternsInstance = &eosPatterns{
 			globalCommentLinePattern: regexp.MustCompile(`(?im)^! .*$`),
 			bannerPattern:            regexp.MustCompile(`(?ims)^banner.*EOF$`),
 			endPattern:               regexp.MustCompile(`end$`),
 		}
-	}
+	})
 
 	return eosPatternsInstance
 }

--- a/cfg/aristaeos.go
+++ b/cfg/aristaeos.go
@@ -21,11 +21,11 @@ type eosPatterns struct {
 
 var (
 	eosPatternsInstance     *eosPatterns //nolint:gochecknoglobals
-	eosPAtternsInstanceOnce sync.Once    //nolint:gochecknoglobals
+	eosPatternsInstanceOnce sync.Once    //nolint:gochecknoglobals
 )
 
 func getEOSPatterns() *eosPatterns {
-	eosPAtternsInstanceOnce.Do(func() {
+	eosPatternsInstanceOnce.Do(func() {
 		eosPatternsInstance = &eosPatterns{
 			globalCommentLinePattern: regexp.MustCompile(`(?im)^! .*$`),
 			bannerPattern:            regexp.MustCompile(`(?ims)^banner.*EOF$`),

--- a/cfg/ciscoiosxr.go
+++ b/cfg/ciscoiosxr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/scrapli/scrapligo/logging"
 
@@ -23,10 +24,13 @@ type iosxrPatterns struct {
 	endPattern           *regexp.Regexp
 }
 
-var iosxrPatternsInstance *iosxrPatterns //nolint:gochecknoglobals
+var (
+	iosxrPatternsInstance     *iosxrPatterns //nolint:gochecknoglobals
+	iosxrPatternsInstanceOnce sync.Once      //nolint:gochecknoglobals
+)
 
 func getIOSXRPatterns() *iosxrPatterns {
-	if iosxrPatternsInstance == nil {
+	iosxrPatternsInstanceOnce.Do(func() {
 		iosxrPatternsInstance = &iosxrPatterns{
 			bannerDelimPattern: regexp.MustCompile(
 				`(?im)(^banner\s(?:exec|incoming|login|motd|prompt-timeout|slip-ppp)\s(.))`,
@@ -51,7 +55,7 @@ func getIOSXRPatterns() *iosxrPatterns {
 				iosxrPatternsInstance.configChangePattern.String(),
 			),
 		)
-	}
+	})
 
 	return iosxrPatternsInstance
 }

--- a/cfg/cisconxos.go
+++ b/cfg/cisconxos.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/scrapli/scrapligo/logging"
@@ -24,10 +25,13 @@ type nxosPatterns struct {
 	checkpointLinePattern *regexp.Regexp
 }
 
-var nxosPatternsInstance *nxosPatterns //nolint:gochecknoglobals
+var (
+	nxosPatternsInstance     *nxosPatterns //nolint:gochecknoglobals
+	nxosPatternsInstanceOnce sync.Once     //nolint:gochecknoglobals
+)
 
 func getNXOSPatterns() *nxosPatterns {
-	if nxosPatternsInstance == nil {
+	nxosPatternsInstanceOnce.Do(func() {
 		nxosPatternsInstance = &nxosPatterns{
 			bytesFreePattern: regexp.MustCompile(
 				`(?i)(?P<bytes_available>\d+)(?: bytes free)`,
@@ -48,7 +52,7 @@ func getNXOSPatterns() *nxosPatterns {
 				nxosPatternsInstance.configChangePattern.String(),
 			),
 		)
-	}
+	})
 
 	return nxosPatternsInstance
 }

--- a/cfg/juniperjunos.go
+++ b/cfg/juniperjunos.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/scrapli/scrapligo/logging"
 
@@ -16,15 +17,18 @@ type junosPatterns struct {
 	editPattern         *regexp.Regexp
 }
 
-var junosPatternsInstance *junosPatterns //nolint:gochecknoglobals
+var (
+	junosPatternsInstance     *junosPatterns //nolint:gochecknoglobals
+	junosPatternsInstanceOnce sync.Once      //nolint:gochecknoglobals
+)
 
 func getJUNOSPatterns() *junosPatterns {
-	if junosPatternsInstance == nil {
+	junosPatternsInstanceOnce.Do(func() {
 		junosPatternsInstance = &junosPatterns{
 			outputHeaderPattern: regexp.MustCompile(`(?im)^## last commit.*$\nversion.*$`),
 			editPattern:         regexp.MustCompile(`(?m)^\[edit\]$`),
 		}
-	}
+	})
 
 	return junosPatternsInstance
 }

--- a/channel/authenticate_test.go
+++ b/channel/authenticate_test.go
@@ -1,0 +1,15 @@
+package channel_test
+
+import (
+	"testing"
+
+	"github.com/scrapli/scrapligo/channel"
+)
+
+// TestGetAuthPatternsRace ensures that the global singleton-y auth patterns getter is goroutine
+// safe.
+func TestGetAuthPatternsRace(t *testing.T) {
+	for i := 1; i < 5; i++ {
+		go channel.GetAuthPatterns()
+	}
+}

--- a/transport/standard.go
+++ b/transport/standard.go
@@ -4,9 +4,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
+	"os"
 
 	"github.com/scrapli/scrapligo/logging"
 
@@ -133,7 +133,7 @@ func (t *Standard) openBase(baseArgs *BaseTransportArgs) error {
 	authMethods := make([]ssh.AuthMethod, 0)
 
 	if t.StandardTransportArgs.AuthPrivateKey != "" {
-		key, err := ioutil.ReadFile(t.StandardTransportArgs.AuthPrivateKey)
+		key, err := os.ReadFile(t.StandardTransportArgs.AuthPrivateKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
follow up from #56 

wrapped all the singleton-y pattern compiling pieces with sync.Once and added a test to make sure that the channel auth patterns fetcher wont cause race condition. had to export some stuff for the patterns business to test but seems like thats not the worst thing ever.

@hellt @networkop does this look reasonable to you gents?


