### PR TITLE
add sonic platform

### DIFF
--- a/driver/core/factory.go
+++ b/driver/core/factory.go
@@ -21,6 +21,7 @@ func SupportedPlatforms() []string {
 		"nokia_sros",
 		"nokia_sros_classic",
 		"paloalto_panos",
+		"sonic_sonic",
 	}
 }
 
@@ -49,6 +50,8 @@ func newCoreDriver(
 		return NewSROSClassicDriver(host, options...)
 	case "paloalto_panos":
 		return NewPanOSDriver(host, options...)
+	case "sonic_sonic":
+		return NewSonicDriver(host, options...)
 	}
 
 	return nil, ErrUnknownPlatform

--- a/driver/core/sonicsonic.go
+++ b/driver/core/sonicsonic.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"github.com/scrapli/scrapligo/driver/base"
+
+	"github.com/scrapli/scrapligo/driver/network"
+)
+
+// NewSonicDriver return a driver setup for operation with Palo Alto Sonic devices.
+func NewSonicDriver(
+	host string,
+	options ...base.Option,
+) (*network.Driver, error) {
+	defaultPrivilegeLevels := map[string]*base.PrivilegeLevel{
+		"exec": {
+			Pattern:        `(?im)^[\w\._-]+@[\w\.\(\)_-]+>\s?`,
+			Name:           execPrivLevel,
+			PreviousPriv:   "",
+			Deescalate:         "disable",
+			Escalate:           "enable",
+			EscalateAuth:       true,
+			EscalatePrompt:     `(?im)^[pP]assword:\s?$`,
+		},
+		"configuration": {
+			Pattern:        `(?im)^[\w\._-]+@[\w\.\(\)_-]+#\s?$`,
+			Name:           configPrivLevel,
+			PreviousPriv:   execPrivLevel,
+			Deescalate:     "exit",
+			Escalate:       "configure",
+			EscalateAuth:   false,
+			EscalatePrompt: "",
+		},
+	}
+	defaultFailedWhenContains := []string{
+		"Unknown command:",
+		"Invalid Syntax.",
+		"Validation Error:",
+	}
+
+	const defaultDefaultDesiredPriv = execPrivLevel
+
+	d, err := network.NewNetworkDriver(
+		host,
+		defaultPrivilegeLevels,
+		defaultDefaultDesiredPriv,
+		defaultFailedWhenContains,
+		SonicOnOpen,
+		SonicOnClose,
+		options...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+// SonicOnOpen default on open callable for Sonic.
+func SonicOnOpen(d *network.Driver) error {
+	err := d.AcquirePriv(d.DefaultDesiredPriv)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SonicOnClose default on close callable for Sonic.
+func SonicOnClose(d *network.Driver) error {
+	err := d.AcquirePriv(d.DefaultDesiredPriv)
+	if err != nil {
+		return err
+	}
+
+	err = d.Channel.Write([]byte("exit"), false)
+	if err != nil {
+		return err
+	}
+
+	err = d.Channel.SendReturn()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/driver/network/common_test.go
+++ b/driver/network/common_test.go
@@ -19,6 +19,7 @@ func platformCommandMapShort() map[string]string {
 		"nokia_sros":         "show version",
 		"nokia_sros_classic": "show version",
 		"paloalto_panos":     "show clock",
+		"sonic_sonic":        "show platfrom summary",
 	}
 }
 
@@ -32,6 +33,7 @@ func platformCommandMapLong() map[string]string {
 		"nokia_sros":         "show router interface",
 		"nokia_sros_classic": "show router interface",
 		"paloalto_panos":     "show templates",
+		"sonic_sonic":        "show version",
 	}
 }
 

--- a/driver/network/sendinteractive_test.go
+++ b/driver/network/sendinteractive_test.go
@@ -104,6 +104,11 @@ func TestSendInteractive(t *testing.T) {
 			continue
 		}
 
+		if platform == "sonic_sonic" {
+			// gotta figure out an interactive command on sros
+			continue
+		}
+
 		sessionFile := fmt.Sprintf("../../test_data/driver/network/sendinteractive/%s", platform)
 
 		d := testhelper.CreatePatchedDriver(t, sessionFile, platform)


### PR DESCRIPTION
Im having a little look at adding sonic to the list of supported platforms so I can use Boxen to stand up Sonic relatively quickly on MacOs (and anywhere else). I really like the minimalist/streamlined code here and have largely scaffolded from the PanOS material because it looks so similar. No Go expert and welcome stewarding of my ability wherever its needed!