### PR TITLE
force self closing tag option

### DIFF
--- a/driver/base/base.go
+++ b/driver/base/base.go
@@ -48,7 +48,8 @@ type Driver struct {
 	PrivilegeLevels    map[string]*PrivilegeLevel
 	DefaultDesiredPriv string
 
-	NetconfEcho *bool
+	NetconfEcho                 *bool
+	NetconfForceSelfClosingTags *bool
 }
 
 // Open opens the connection.

--- a/driver/base/options.go
+++ b/driver/base/options.go
@@ -220,12 +220,12 @@ func WithNetconfServerEcho(echo bool) Option {
 
 // WithNetconfForceSelfClosingTags forces empty tags to the form </tag> -- only applicable for
 // netconf, and *probably* only for junos.
-func WithNetconfForceSelfClosingTags(echo bool) Option {
+func WithNetconfForceSelfClosingTags(forceSelfClosingTags bool) Option {
 	return func(o interface{}) error {
 		d, ok := o.(*Driver)
 
 		if ok {
-			d.NetconfForceSelfClosingTags = &echo
+			d.NetconfForceSelfClosingTags = &forceSelfClosingTags
 			return nil
 		}
 

--- a/driver/base/options.go
+++ b/driver/base/options.go
@@ -218,6 +218,21 @@ func WithNetconfServerEcho(echo bool) Option {
 	}
 }
 
+// WithNetconfForceSelfClosingTags forces empty tags to the form </tag> -- only applicable for
+// netconf, and *probably* only for junos.
+func WithNetconfForceSelfClosingTags(echo bool) Option {
+	return func(o interface{}) error {
+		d, ok := o.(*Driver)
+
+		if ok {
+			d.NetconfForceSelfClosingTags = &echo
+			return nil
+		}
+
+		return ErrIgnoredOption
+	}
+}
+
 // Send command/config options
 
 const (

--- a/netconf/channel.go
+++ b/netconf/channel.go
@@ -15,7 +15,7 @@ type Channel struct {
 	BaseChannel             *channel.Channel
 	PreferredNetconfVersion string
 	SelectedNetconfVersion  string
-	ForceSelfClosingTag     bool
+	ForceSelfClosingTag     *bool
 	serverCapabilities      []string
 	serverEcho              *bool
 }

--- a/netconf/driver.go
+++ b/netconf/driver.go
@@ -47,8 +47,9 @@ func NewNetconfDriver(
 	}
 
 	nc := &Channel{
-		BaseChannel: d.Channel,
-		serverEcho:  d.NetconfEcho,
+		BaseChannel:         d.Channel,
+		serverEcho:          d.NetconfEcho,
+		ForceSelfClosingTag: d.NetconfForceSelfClosingTags,
 	}
 
 	d.NetconfChannel = nc

--- a/netconf/getconfig_test.go
+++ b/netconf/getconfig_test.go
@@ -48,7 +48,8 @@ func TestFunctionalGetConfig(t *testing.T) {
 			d := newFunctionalTestDriver(t, connectionData.Host, transportName, connectionData.Port)
 
 			if strings.Contains(platform, "junos") {
-				d.NetconfChannel.ForceSelfClosingTag = true
+				t := true
+				d.NetconfChannel.ForceSelfClosingTag = &t
 			}
 
 			f := testFunctionalGetConfig(d)

--- a/netconf/message.go
+++ b/netconf/message.go
@@ -16,7 +16,7 @@ func (c *Channel) BuildFinalMessage(xmlMessage interface{}) ([]byte, error) {
 
 	message = append([]byte(XMLHeader), message...)
 
-	if c.ForceSelfClosingTag {
+	if *c.ForceSelfClosingTag {
 		// this grossness is 100% only for junos who seem to have lost their ever loving mind...
 		// `<source><running></running></source>` will cause junos (at least 17.x) to return an
 		// error whilst `<source><running/></source>` will not. functionally 100% identical but


### PR DESCRIPTION
follow up from #73

so... it turns out that I eventually remembered this self closing tag debacle because I had already gone down this road 🤣 

`ForceSelfClosingTag` was already a field on the netconf channel -- so you could create a netconf connection and do `conn.Channel.ForceSelfClosignTag = true`. But I went ahead and added an option for it as well so its a little nicer now.

all of this really has reinforced that I need to take some time at some point to overhaul this and get it to a 1.0 state, but.... that won't be for a while probably, so hopefully this works in the short term!

@horseinthesky can ya give this a shot? 