### PR TITLE
add open args override and open bin options for system transport

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -57,7 +57,5 @@ jobs:
         run: bash -c "$(curl -sL https://get.containerlab.dev)" -- -v 0.26.2
       - name: start clab ci topo
         run: make deploy-clab-ci
-      - name: wait for srlinux node
-        run: sleep 60
       - name: tests
         run: make test-ci

--- a/driver/options/transportsystem.go
+++ b/driver/options/transportsystem.go
@@ -5,6 +5,22 @@ import (
 	"github.com/scrapli/scrapligo/util"
 )
 
+// WithSystemTransportOpenBin sets the binary to be used when opening a System Transport
+// connection.
+func WithSystemTransportOpenBin(s string) util.Option {
+	return func(o interface{}) error {
+		t, ok := o.(*transport.System)
+
+		if !ok {
+			return util.ErrIgnoredOption
+		}
+
+		t.OpenBin = s
+
+		return nil
+	}
+}
+
 // WithSystemTransportOpenArgs sets the ExtraArgs value of the System Transport, these arguments are
 // appended to the System transport open command (the command that spawns the connection).
 func WithSystemTransportOpenArgs(l []string) util.Option {
@@ -16,6 +32,22 @@ func WithSystemTransportOpenArgs(l []string) util.Option {
 		}
 
 		t.ExtraArgs = append(t.ExtraArgs, l...)
+
+		return nil
+	}
+}
+
+// WithSystemTransportOpenArgsOverride sets the arguments used when opening a System Transport
+// connection. When explicitly setting arguments in this fashion all ExtraArgs will be ignored.
+func WithSystemTransportOpenArgsOverride(l []string) util.Option {
+	return func(o interface{}) error {
+		t, ok := o.(*transport.System)
+
+		if !ok {
+			return util.ErrIgnoredOption
+		}
+
+		t.OpenArgs = l
 
 		return nil
 	}

--- a/driver/options/transportsystem_test.go
+++ b/driver/options/transportsystem_test.go
@@ -13,6 +13,61 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func testSystemTransportOpenBin(
+	testName string,
+	testCase *optionsStringTestCase,
+) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Logf("%s: starting", testName)
+
+		err := options.WithSystemTransportOpenBin(testCase.s)(testCase.o)
+		if err != nil {
+			if errors.Is(err, util.ErrIgnoredOption) && !testCase.isignored {
+				t.Fatalf(
+					"%s: option should be ignored, but returned different error",
+					testName,
+				)
+			}
+
+			return
+		}
+
+		oo, _ := testCase.o.(*transport.System)
+
+		if !cmp.Equal(oo.OpenBin, testCase.s) {
+			t.Fatalf(
+				"%s: actual and expected transport open bin do not match\nactual: %v\nexpected:%v",
+				testName,
+				oo.ExtraArgs,
+				testCase.s,
+			)
+		}
+	}
+}
+
+func TestSystemTransportOpenBin(t *testing.T) {
+	cases := map[string]*optionsStringTestCase{
+		"set-system-transport-open-args": {
+			description: "simple set option test",
+			s:           "racocar",
+			o:           &transport.System{},
+			isignored:   false,
+		},
+		"ignored": {
+			description: "skipped due to ignored type",
+			s:           "tacocat",
+			o:           &generic.Driver{},
+			isignored:   true,
+		},
+	}
+
+	for testName, testCase := range cases {
+		f := testSystemTransportOpenBin(testName, testCase)
+
+		t.Run(testName, f)
+	}
+}
+
 func testSystemTransportOpenArgs(
 	testName string,
 	testCase *optionsStringSliceTestCase,
@@ -63,6 +118,61 @@ func TestSystemTransportOpenArgs(t *testing.T) {
 
 	for testName, testCase := range cases {
 		f := testSystemTransportOpenArgs(testName, testCase)
+
+		t.Run(testName, f)
+	}
+}
+
+func testSystemTransportOpenArgsOverride(
+	testName string,
+	testCase *optionsStringSliceTestCase,
+) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Logf("%s: starting", testName)
+
+		err := options.WithSystemTransportOpenArgsOverride(testCase.ss)(testCase.o)
+		if err != nil {
+			if errors.Is(err, util.ErrIgnoredOption) && !testCase.isignored {
+				t.Fatalf(
+					"%s: option should be ignored, but returned different error",
+					testName,
+				)
+			}
+
+			return
+		}
+
+		oo, _ := testCase.o.(*transport.System)
+
+		if !cmp.Equal(oo.OpenArgs, testCase.ss) {
+			t.Fatalf(
+				"%s: actual and expected transport open args do not match\nactual: %v\nexpected:%v",
+				testName,
+				oo.OpenArgs,
+				testCase.ss,
+			)
+		}
+	}
+}
+
+func TestSystemTransportOpenArgsOverride(t *testing.T) {
+	cases := map[string]*optionsStringSliceTestCase{
+		"set-system-transport-open-args": {
+			description: "simple set option test",
+			ss:          []string{"some", "neat", "args"},
+			o:           &transport.System{},
+			isignored:   false,
+		},
+		"ignored": {
+			description: "skipped due to ignored type",
+			ss:          []string{"some", "neat", "args"},
+			o:           &generic.Driver{},
+			isignored:   true,
+		},
+	}
+
+	for testName, testCase := range cases {
+		f := testSystemTransportOpenArgsOverride(testName, testCase)
 
 		t.Run(testName, f)
 	}

--- a/transport/system.go
+++ b/transport/system.go
@@ -22,8 +22,8 @@ const (
 func NewSystemTransport(a *SSHArgs) (*System, error) {
 	t := &System{
 		SSHArgs:  a,
-		openBin:  defaultOpenBin,
-		openArgs: make([]string, 0),
+		OpenBin:  defaultOpenBin,
+		OpenArgs: make([]string, 0),
 		fd:       nil,
 	}
 
@@ -34,17 +34,17 @@ func NewSystemTransport(a *SSHArgs) (*System, error) {
 type System struct {
 	SSHArgs   *SSHArgs
 	ExtraArgs []string
-	openBin   string
-	openArgs  []string
+	OpenBin   string
+	OpenArgs  []string
 	fd        *os.File
 }
 
 func (t *System) buildOpenArgs(a *Args) {
-	if len(t.openArgs) > 0 {
-		t.openArgs = []string{}
+	if len(t.OpenArgs) > 0 {
+		t.OpenArgs = []string{}
 	}
 
-	t.openArgs = []string{
+	t.OpenArgs = []string{
 		a.Host,
 		"-p",
 		fmt.Sprintf("%d", a.Port),
@@ -55,30 +55,30 @@ func (t *System) buildOpenArgs(a *Args) {
 	}
 
 	if a.User != "" {
-		t.openArgs = append(
-			t.openArgs,
+		t.OpenArgs = append(
+			t.OpenArgs,
 			"-l",
 			a.User,
 		)
 	}
 
 	if t.SSHArgs.StrictKey {
-		t.openArgs = append(
-			t.openArgs,
+		t.OpenArgs = append(
+			t.OpenArgs,
 			"-o",
 			"StrictHostKeyChecking=yes",
 		)
 
 		if t.SSHArgs.KnownHostsFile != "" {
-			t.openArgs = append(
-				t.openArgs,
+			t.OpenArgs = append(
+				t.OpenArgs,
 				"-o",
 				fmt.Sprintf("UserKnownHostsFile=%s", t.SSHArgs.KnownHostsFile),
 			)
 		}
 	} else {
-		t.openArgs = append(
-			t.openArgs,
+		t.OpenArgs = append(
+			t.OpenArgs,
 			"-o",
 			"StrictHostKeyChecking=no",
 			"-o",
@@ -87,35 +87,35 @@ func (t *System) buildOpenArgs(a *Args) {
 	}
 
 	if t.SSHArgs.ConfigFile != "" {
-		t.openArgs = append(
-			t.openArgs,
+		t.OpenArgs = append(
+			t.OpenArgs,
 			"-F",
 			t.SSHArgs.ConfigFile,
 		)
 	} else {
-		t.openArgs = append(
-			t.openArgs,
+		t.OpenArgs = append(
+			t.OpenArgs,
 			"-F",
 			"/dev/null",
 		)
 	}
 
 	if len(t.ExtraArgs) > 0 {
-		t.openArgs = append(
-			t.openArgs,
+		t.OpenArgs = append(
+			t.OpenArgs,
 			t.ExtraArgs...,
 		)
 	}
 }
 
 func (t *System) open(a *Args) error {
-	if len(t.openArgs) == 0 {
+	if len(t.OpenArgs) == 0 {
 		t.buildOpenArgs(a)
 	}
 
-	a.l.Debugf("opening system transport with bin '%s' and args '%s'", t.openBin, t.openArgs)
+	a.l.Debugf("opening system transport with bin '%s' and args '%s'", t.OpenBin, t.OpenArgs)
 
-	c := exec.Command(t.openBin, t.openArgs...) //nolint:gosec
+	c := exec.Command(t.OpenBin, t.OpenArgs...) //nolint:gosec
 
 	var err error
 
@@ -136,15 +136,15 @@ func (t *System) open(a *Args) error {
 }
 
 func (t *System) openNetconf(a *Args) error {
-	if len(t.openArgs) == 0 {
+	if len(t.OpenArgs) == 0 {
 		t.buildOpenArgs(a)
 	}
 
-	t.openArgs = append(t.openArgs, "-s", "netconf")
+	t.OpenArgs = append(t.OpenArgs, "-s", "netconf")
 
-	a.l.Debugf("opening system transport with bin '%s' and args '%s'", t.openBin, t.openArgs)
+	a.l.Debugf("opening system transport with bin '%s' and args '%s'", t.OpenBin, t.OpenArgs)
 
-	c := exec.Command(t.openBin, t.openArgs...) //nolint:gosec
+	c := exec.Command(t.OpenBin, t.OpenArgs...) //nolint:gosec
 
 	var err error
 


### PR DESCRIPTION
title! exposing the system transport args and bin is important for projects like clab that use scrapligo to connect to containers, this was missed in the v1 overhaul, so adding now.