### PR TITLE
convey driver' failedwhencontains to send command ops

### DIFF
--- a/driver/generic/operation.go
+++ b/driver/generic/operation.go
@@ -18,9 +18,9 @@ type OperationOptions struct {
 
 // NewOperation returns a new OperationOptions object with the defaults set and any provided options
 // applied.
-func NewOperation(options ...util.Option) (*OperationOptions, error) {
+func (d *Driver) NewOperation(options ...util.Option) (*OperationOptions, error) {
 	o := &OperationOptions{
-		FailedWhenContains: []string{},
+		FailedWhenContains: d.FailedWhenContains,
 		StopOnFailed:       defaultStopOnFailed,
 	}
 

--- a/driver/generic/sendcommand.go
+++ b/driver/generic/sendcommand.go
@@ -31,7 +31,7 @@ func (d *Driver) sendCommand(
 
 // SendCommand sends the input string to the device and returns a response.Response object.
 func (d *Driver) SendCommand(command string, opts ...util.Option) (*response.Response, error) {
-	op, err := NewOperation(opts...)
+	op, err := d.NewOperation(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/generic/sendcommands.go
+++ b/driver/generic/sendcommands.go
@@ -11,6 +11,7 @@ func (d *Driver) SendCommands(
 	opts ...util.Option,
 ) (*response.MultiResponse, error) {
 	d.Logger.Infof("SendCommands requested, sending '%s'", commands)
+
 	op, err := d.NewOperation(opts...)
 	if err != nil {
 		return nil, err

--- a/driver/generic/sendcommands.go
+++ b/driver/generic/sendcommands.go
@@ -11,8 +11,7 @@ func (d *Driver) SendCommands(
 	opts ...util.Option,
 ) (*response.MultiResponse, error) {
 	d.Logger.Infof("SendCommands requested, sending '%s'", commands)
-
-	op, err := NewOperation(opts...)
+	op, err := d.NewOperation(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/generic/sendinteractive.go
+++ b/driver/generic/sendinteractive.go
@@ -24,7 +24,7 @@ func (d *Driver) SendInteractive(
 	events []*channel.SendInteractiveEvent,
 	opts ...util.Option,
 ) (*response.Response, error) {
-	op, err := NewOperation(opts...)
+	op, err := d.NewOperation(opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
failed-when-contains list is not preserved when send* opertaions are called.
This is a hot fix for that, but maybe you see wholes in that solution and there is a better way to do that