### PR TITLE
refactor slices_test to match go style

### DIFF
--- a/util/slices_test.go
+++ b/util/slices_test.go
@@ -1,46 +1,31 @@
-package util_test
+package util
 
 import (
 	"testing"
-
-	"github.com/scrapli/scrapligo/util"
 )
 
-func testStringSliceContains(testName, s string, ss []string, expected bool) func(t *testing.T) {
-	return func(t *testing.T) {
-		t.Logf("%s: starting", testName)
-
-		if util.StringSliceContains(ss, s) != expected {
-			t.Fatalf(
-				"%s: actual and expected results differ",
-				testName,
-			)
-		}
-	}
-}
-
 func TestStringSliceContains(t *testing.T) {
-	cases := map[string]struct {
-		description string
-		ss          []string
-		s           string
-		expected    bool
-	}{
-		"string-slice-contains-simple-true": {
-			ss:       []string{"taco", "cat", "race", "car"},
-			s:        "taco",
-			expected: true,
-		},
-		"string-slice-contains-simple-false": {
-			ss:       []string{"taco", "cat", "race", "car"},
-			s:        "potato",
-			expected: false,
-		},
-	}
-
-	for testName, testCase := range cases {
-		f := testStringSliceContains(testName, testCase.s, testCase.ss, testCase.expected)
-
-		t.Run(testName, f)
+	tests := []struct {
+		desc string
+		ss   []string
+		s    string
+		want bool
+	}{{
+		desc: "string-slice-contains-simple-true",
+		ss:   []string{"taco", "cat", "race", "car"},
+		s:    "taco",
+		want: true,
+	}, {
+		desc: "string-slice-contains-simple-false",
+		ss:   []string{"taco", "cat", "race", "car"},
+		s:    "potato",
+		want: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := StringSliceContains(tt.ss, tt.s); got != tt.want {
+				t.Fatalf("StringSliceContains(%v, %q) failed: got %v, want %v", tt.ss, tt.s, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
I would suggest restructuring your tests to follow this style
it actually makes the test more readable as there is not an unneeded level of function indirection
also moving the tests to the same package as what they test is go style

If you are okay with this pattern i am happy to help refactor

I was importing your code into a repo and noticed this pattern as well as you have a very standard pattern for your file io which i would suggest could be standardized as a library also for build systems such as bazel - you cannot read and write files the way you are doing in the tests and i would suggest there are some packages which might be better suited for doing test file reads/writes