### PR TITLE
propagate multiresponse failed status to the combined response of SendConfig

### DIFF
--- a/assets/platforms/nokia_srl.yaml
+++ b/assets/platforms/nokia_srl.yaml
@@ -24,6 +24,7 @@ default:
   default-desired-privilege-level: "exec"
   failed-when-contains:
     - "Error:"
+    - "error:" # wildcard catch for errors like `Validation error:`, `Parsing error:`
   textfsm-platform: "" # ignored in go because no ntc-templates
   network-on-open:
     - operation: "acquire-priv" # targets default desired priv by default

--- a/driver/network/sendconfig.go
+++ b/driver/network/sendconfig.go
@@ -35,6 +35,7 @@ func (d *Driver) SendConfig(config string, opts ...util.Option) (*response.Respo
 	r.EndTime = time.Now()
 	r.ElapsedTime = r.EndTime.Sub(r.StartTime).Seconds()
 	r.Result = strings.Join(rOutputs, "\n")
+	r.Failed = m.Failed
 
 	return r, nil
 }


### PR DESCRIPTION
@carlmontanari as discussed before, this does the trick. Please let me know if this is not the best place to do that, but it works.

```go
	resp, err := n.cliConn.SendConfig(cfgs, scrapliopopts.WithStopOnFailed())
	if err != nil {
		return err
	}

	if resp.Failed == nil {
		log.Infof("%s - finshed config push", n.Impl.Proto.Name)
	}

	return resp.Failed
```

output:

```
INFO[0001]     INFO SendCommand requested, sending 'set / system infation location "set with config push"' 
INFO[0001]    DEBUG channel SendInput requested, sending input 'set / system infation location "set with config push"' 
INFO[0001]    DEBUG channel write "set / system infation location \"set with config push\"" 
INFO[0001]    DEBUG channel read "set / system infation location \"set with config push\"" 
INFO[0001]    DEBUG channel write "\n"         
INFO[0001]    DEBUG channel read "\nParsing error: Unknown token 'infation'. Options are ['!!', '!!!', '#', '>', '>>', 'aaa', 'authentication', 'banner', 'boot', 'bridge-table', 'clock', 'configuration', 'dhcp-server', 'dns', 'event-handler', 'ftp-server', 'gnmi-server', 'information', 'json-rpc-server', 'lacp', 'lldp', 'load-balancing', 'logging', 'maintenance', 'management', 'mirroring', 'mtu', 'name', 'network-instance', 'ntp', 'ra-guard-policy', 'sflow', 'snmp', 'ssh-server', 'tls', 'trace-options', 'warm-reboot', '|']\n--{ candidate private private-root }--[  ]--\nA:r1# " 
INFO[0001]     INFO encountered failed command, and stop on failed is true, discontinuing send commands operation 

--snip--

INFO[0001]     INFO connection closed successfully 
Error: operation error from input 'set / system infation location "set with config push"'. indicated error 'error:'
```

PS. I wonder if the error should contain the full error message? In the output above you see that "indicated error" only specifies the "failed-when-contains" string (`error:`), and not the full error string as shown in the debug output above

```
DEBUG channel read "\nParsing error: Unknown token 'infation'. Options are ['!!', '!!!', '#', '>', '>>', 'aaa', 'authentication', 'banner', 'boot', 'bridge-table', 'clock', 'configuration', 'dhcp-server', 'dns', 'event-handler', 'ftp-server', 'gnmi-server', 'information', 'json-rpc-server', 'lacp', 'lldp', 'load-balancing', 'logging', 'maintenance', 'management', 'mirroring', 'mtu', 'name', 'network-instance', 'ntp', 'ra-guard-policy', 'sflow', 'snmp', 'ssh-server', 'tls', 'trace-options', 'warm-reboot', '|']\n--{ candidate private private-root }--[  ]--\nA:r1# " 
```