### PR TITLE
updates to NETCONF error checking & adding subscription example

### DIFF
--- a/driver/netconf/driver.go
+++ b/driver/netconf/driver.go
@@ -46,6 +46,8 @@ const (
 	messageIDPattern      = `(?i)(?:message-id="(\d+)")`
 	subscriptionIDPattern = `(?i)<subscription-id.*>(\d+)</subscription-id>`
 
+	subscriptionResultPattern = `(?i)<subscription-result.*>notif-bis:(.+)</subscription-result>`
+
 	emptyTagPattern = `<(\w+)></\w+>`
 
 	defaultNamespace = "urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults"
@@ -54,13 +56,14 @@ const (
 )
 
 type netconfPatterns struct {
-	v1Dot0Delim    *regexp.Regexp
-	v1Dot1Delim    *regexp.Regexp
-	hello          *regexp.Regexp
-	capability     *regexp.Regexp
-	messageID      *regexp.Regexp
-	subscriptionID *regexp.Regexp
-	emptyTags      *regexp.Regexp
+	v1Dot0Delim        *regexp.Regexp
+	v1Dot1Delim        *regexp.Regexp
+	hello              *regexp.Regexp
+	capability         *regexp.Regexp
+	messageID          *regexp.Regexp
+	subscriptionID     *regexp.Regexp
+	subscriptionResult *regexp.Regexp
+	emptyTags          *regexp.Regexp
 }
 
 var (
@@ -71,13 +74,14 @@ var (
 func getNetconfPatterns() *netconfPatterns {
 	netconfPatternsInstanceOnce.Do(func() {
 		netconfPatternsInstance = &netconfPatterns{
-			v1Dot0Delim:    regexp.MustCompile(v1Dot0Delim),
-			v1Dot1Delim:    regexp.MustCompile(v1Dot1Delim),
-			hello:          regexp.MustCompile(helloPattern),
-			capability:     regexp.MustCompile(capabilityPattern),
-			messageID:      regexp.MustCompile(messageIDPattern),
-			subscriptionID: regexp.MustCompile(subscriptionIDPattern),
-			emptyTags:      regexp.MustCompile(emptyTagPattern),
+			v1Dot0Delim:        regexp.MustCompile(v1Dot0Delim),
+			v1Dot1Delim:        regexp.MustCompile(v1Dot1Delim),
+			hello:              regexp.MustCompile(helloPattern),
+			capability:         regexp.MustCompile(capabilityPattern),
+			messageID:          regexp.MustCompile(messageIDPattern),
+			subscriptionID:     regexp.MustCompile(subscriptionIDPattern),
+			subscriptionResult: regexp.MustCompile(subscriptionResultPattern),
+			emptyTags:          regexp.MustCompile(emptyTagPattern),
 		}
 	})
 

--- a/driver/netconf/rpc.go
+++ b/driver/netconf/rpc.go
@@ -112,5 +112,9 @@ func (d *Driver) sendRPC(
 		r.Record(data)
 	}
 
+	if r.Failed != nil {
+		return nil, r.Failed
+	}
+
 	return r, nil
 }

--- a/driver/netconf/rpc.go
+++ b/driver/netconf/rpc.go
@@ -112,9 +112,5 @@ func (d *Driver) sendRPC(
 		r.Record(data)
 	}
 
-	if r.Failed != nil {
-		return nil, r.Failed
-	}
-
 	return r, nil
 }

--- a/driver/netconf/subscription.go
+++ b/driver/netconf/subscription.go
@@ -2,9 +2,11 @@ package netconf
 
 import (
 	"encoding/xml"
+	"fmt"
 	"strconv"
 
 	"github.com/scrapli/scrapligo/response"
+	"github.com/scrapli/scrapligo/util"
 )
 
 type establishSubscription struct {
@@ -39,6 +41,12 @@ func (d *Driver) EstablishPeriodicSubscription(
 	}
 
 	patterns := getNetconfPatterns()
+
+	subscriptionResult := patterns.subscriptionResult.FindSubmatch(r.RawResult)
+
+	if string(subscriptionResult[1]) != "ok" {
+		return nil, fmt.Errorf("%w: subscription failed: %v", util.ErrNetconfError, string(subscriptionResult[1]))
+	}
 
 	match := patterns.subscriptionID.FindSubmatch(r.RawResult)
 	subID, _ := strconv.Atoi(string(match[1]))

--- a/driver/netconf/subscription.go
+++ b/driver/netconf/subscription.go
@@ -45,7 +45,11 @@ func (d *Driver) EstablishPeriodicSubscription(
 	subscriptionResult := patterns.subscriptionResult.FindSubmatch(r.RawResult)
 
 	if string(subscriptionResult[1]) != "ok" {
-		return nil, fmt.Errorf("%w: subscription failed: %v", util.ErrNetconfError, string(subscriptionResult[1]))
+		return nil, fmt.Errorf(
+			"%w: subscription failed: %v",
+			util.ErrNetconfError,
+			string(subscriptionResult[1]),
+		)
 	}
 
 	match := patterns.subscriptionID.FindSubmatch(r.RawResult)

--- a/driver/netconf/subscription.go
+++ b/driver/netconf/subscription.go
@@ -40,6 +40,11 @@ func (d *Driver) EstablishPeriodicSubscription(
 		return nil, err
 	}
 
+	// sendRPC didn't error, but we got some failed message, subscription establishment failed...
+	if r.Failed != nil {
+		return r, r.Failed
+	}
+
 	patterns := getNetconfPatterns()
 
 	subscriptionResult := patterns.subscriptionResult.FindSubmatch(r.RawResult)

--- a/examples/netconf_driver/periodic_subscription/README.md
+++ b/examples/netconf_driver/periodic_subscription/README.md
@@ -1,0 +1,12 @@
+NETCONF Periodic Subscription
+======
+
+Using NETCONF, we can subscribe to continuous updates from a YANG datastore. This is accomplished
+easily using the `EstablishPeriodicSubscription` method, which requires two parameters. 
+An `xpath` filter is provided to tell the target device which YANG datastore to send updates for. 
+The `period` value specifies the interval in which the device should push updates.
+
+In the example code we subscribe to `/interfaces/interface[name=\"GigabitEthernet1\"]/statistics`
+which contains operational state data on interface `GigabitEthernet1` (in/out packets, errors, etc). 
+The period is specified as `1000` centiseconds, or 10 seconds. Any subscription messages received
+from the device can be retrieved using `GetSubscriptionMessages` and passing the subscription ID.

--- a/examples/netconf_driver/periodic_subscription/main.go
+++ b/examples/netconf_driver/periodic_subscription/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/scrapli/scrapligo/driver/netconf"
+	"github.com/scrapli/scrapligo/driver/options"
+)
+
+func main() {
+	d, err := netconf.NewDriver(
+		"sandbox-iosxe-latest-1.cisco.com",
+		options.WithAuthNoStrictKey(),
+		options.WithAuthUsername("developer"),
+		options.WithAuthPassword("C1sco12345"),
+		options.WithPort(830),
+	)
+	if err != nil {
+		fmt.Printf("failed to create driver; error: %+v\n", err)
+
+		return
+	}
+
+	err = d.Open()
+	if err != nil {
+		fmt.Printf("failed to open driver; error: %+v\n", err)
+
+		return
+	}
+
+	defer d.Close()
+
+	xpath := "/interfaces/interface[name=\"GigabitEthernet1\"]/statistics"
+	period := 1000
+	resp, err := d.EstablishPeriodicSubscription(xpath, period)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("Subscription ID: ", resp.SubscriptionID)
+
+	for {
+		fmt.Println("Checking for messages...")
+		messages := d.GetSubscriptionMessages(resp.SubscriptionID)
+		for _, event := range messages {
+			fmt.Println("Event Received:")
+			fmt.Println(string([]byte(event)))
+		}
+		time.Sleep(1 * time.Second)
+	}
+}


### PR DESCRIPTION
Hi there - Working through some development & testing of NETCONF/YANG periodic subscriptions and came across a few minor issues. Also wanted to contribute a short example of how to use the subscriptions. 

Two issues I discovered while trying to esablish subscriptions:
- providing a `period` value that is too high, and the device responds with an RPC error
- providing a `period` value that is too low, and the device responds with a valid `<subscription-result>` tag that contains an error

I am using Cisco IOS-XE version 17.6.3 for my testing.

---

For reference, here is an example of a **GOOD** response from a successful session establishment:
```
<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><subscription-result xmlns='urn:ietf:params:xml:ns:yang:ietf-event-notifications' xmlns:notif-bis="urn:ietf:params:xml:ns:yang:ietf-event-notifications">notif-bis:ok</subscription-result>

<subscription-id xmlns='urn:ietf:params:xml:ns:yang:ietf-event-notifications'>2147483682</subscription-id>
</rpc-reply>
```

---

When providing a `period` value that is too low (for example, 2 centiseconds):
```
<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><subscription-result xmlns='urn:ietf:params:xml:ns:yang:ietf-event-notifications' xmlns:notif-bis="urn:ietf:params:xml:ns:yang:ietf-event-notifications">notif-bis:error-insufficient-resources</subscription-result>
</rpc-reply>
```

scrapligo panics:
```
panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
github.com/scrapli/scrapligo/driver/netconf.(*Driver).EstablishPeriodicSubscription(0xc0000ac370, {0x6779f9, 0x51}, 0x2)
        /home/matt/scrapligo/driver/netconf/subscription.go:44 +0x245
main.main()
        /home/mattsc/scrapligo-test/main.go:37 +0x1f9
exit status 2
```

---

When providing a `period` value that is too high (for example, 2,000,000,000,000,000,000 centiseconds):
```
<?xml version="1.0" encoding="UTF-8"?>
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><rpc-error>
<error-type>protocol</error-type>
<error-tag>invalid-value</error-tag>
<error-severity>error</error-severity>
<error-path xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push" xmlns:notif-bis="urn:ietf:params:xml:ns:yang:ietf-event-notifications">
    /rpc/notif-bis:establish-subscription/yp:period
  </error-path>
  <error-message xml:lang="en">"2000000000000000000" is not a valid value.</error-message>
  <error-info><bad-element>period</bad-element>
</error-info>
</rpc-error>
</rpc-reply>
```

scrapligo panics here as well:
```
panic: runtime error: index out of range [1] with length 0

goroutine 1 [running]:
github.com/scrapli/scrapligo/driver/netconf.(*Driver).EstablishPeriodicSubscription(0xc0000ac370, {0x6779f9, 0x51}, 0x1bc16d674ec80000)
        /home/matt/scrapligo/driver/netconf/subscription.go:44 +0x245
main.main()
        /home/mattsc/scrapligo-test/main.go:37 +0x1fe
exit status 2
```

For this case, I did see that scrapligo is checking against a list of values defined in `FailedWhenContains` - which does include `<rpc-error>`. But I didn't see anywhere this was generating an error. The RPC response was then being returned to the `EstablishPeriodicSubscription` method, which then errors when trying to access elements in the XML response.

I wasn't sure if it was better to check for `r.Failed != nil` in `subscription.go`, or if it should be more general for any other RPC calls that failed. I opted to go for adding this to `rpc.go` in the `sendRPC` method immediately after checking through the `FailedWhenContains` list. 

If that's not the ideal place, I'm happy to move it! 

Thanks!! 


 

