### PR TITLE
channel: don't leak go routine on close

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -65,7 +65,7 @@ func NewChannel(
 		PromptPattern:     getPromptPattern(),
 		ReturnChar:        []byte(DefaultReturnChar),
 
-		done: make(chan bool),
+		done: make(chan struct{}),
 
 		Q:    util.NewQueue(),
 		Errs: make(chan error),
@@ -105,7 +105,7 @@ type Channel struct {
 	PromptPattern     *regexp.Regexp
 	ReturnChar        []byte
 
-	done chan bool
+	done chan struct{}
 
 	Q    *util.Queue
 	Errs chan error
@@ -172,9 +172,8 @@ func (c *Channel) Close() error {
 	ch := make(chan struct{})
 
 	go func() {
-		c.done <- true
-
-		ch <- struct{}{}
+		c.done <- struct{}{}
+		close(ch)
 	}()
 
 	select {

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -173,6 +173,7 @@ func (c *Channel) Close() error {
 
 	go func() {
 		c.done <- struct{}{}
+
 		close(ch)
 	}()
 


### PR DESCRIPTION
The channel close has some timeout logic for block reads.  If the timeout is hit (the `<-time.After(c.ReadDelay * (c.ReadDelay / readDelayDivisor) branch) then the go routine will block forever.

This changes the channel send to a `close` which will not block.  Closed go routines will always send the zero value on any receivers which will do the right thing in both cases.  

I am pretty sure there are other goroutine leaks in closing connections as well.  `c.done` is used to signal closing of the channel but on the `read()` method there is a good chance the connection is blocking on c.Read() and so `c.done` is probably not going to be read:

[func (c *Channel) read() {](https://github.com/nemith/scrapligo/blob/b63aa6ec4f71dd02eb6647795660481d9f14a390/channel/read.go#L13-L22). 

`transport.Read()` probably won't not block until closed, so the order of operation is backwards, but I haven't had a chance to dig into it and probably wont' be but something to look/test for. 