### PR TITLE
Close opened transports if authentication fails in Channel.Open.

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -115,13 +115,20 @@ type Channel struct {
 
 // Open opens the underlying Transport and begins the `read` goroutine, this also kicks off any
 // in channel authentication (if necessary).
-func (c *Channel) Open() error {
+func (c *Channel) Open() (rerr error) {
 	err := c.t.Open()
 	if err != nil {
 		c.l.Criticalf("error opening channel, error: %s", err)
 
 		return err
 	}
+	defer func() {
+		if rerr != nil {
+			// Don't leave the trasnport open if we are
+			// going to return an error.
+			c.t.Close(false)
+		}
+	}()
 
 	c.l.Debug("starting channel read loop")
 

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -115,7 +115,7 @@ type Channel struct {
 
 // Open opens the underlying Transport and begins the `read` goroutine, this also kicks off any
 // in channel authentication (if necessary).
-func (c *Channel) Open() (rerr error) {
+func (c *Channel) Open() (reterr error) {
 	err := c.t.Open()
 	if err != nil {
 		c.l.Criticalf("error opening channel, error: %s", err)
@@ -124,9 +124,10 @@ func (c *Channel) Open() (rerr error) {
 	}
 
 	defer func() {
-		if rerr != nil {
-			// Don't leave the transport open if we are
-			// going to return an error.
+		if reterr != nil {
+			// don't leave the transport open if we are going to return an error -- especially
+			// important for system transport which may leave ptys hanging open if not closed
+			// nicely, see #135.
 			_ = c.Close()
 		}
 	}()


### PR DESCRIPTION
We have seen problems that end up with `read /dev/ptmx: input/output error`.  The underlying cause is that we have run out of ptys.  Examining Channel.Open it appears that it is calling System.Open which in turns calls pty.StartWithSize.  If this open succeeds but Channel.Open ultimately returns an error the underlying pty is never closed.

Please review this PR to determine if this change should be necessary or not.  Thanks.