### PR TITLE
Store the Netconf session ID and expose it using driver.SessionID()

### DIFF
--- a/driver/netconf/capabilities.go
+++ b/driver/netconf/capabilities.go
@@ -7,6 +7,10 @@ import (
 	"github.com/scrapli/scrapligo/util"
 )
 
+const (
+	numSessionIDMatches = 2
+)
+
 // ServerHasCapability returns true if the server supports capability s, otherwise false.
 func (d *Driver) ServerHasCapability(s string) bool {
 	for _, serverCapability := range d.serverCapabilities {
@@ -26,8 +30,8 @@ func (d *Driver) ServerCapabilities() []string {
 	return append(caps, d.serverCapabilities...)
 }
 
+// SessionID returns the session ID sent by the server in the initial Hello message.
 func (d *Driver) SessionID() uint64 {
-
 	return d.sessionID
 }
 
@@ -55,14 +59,16 @@ func (d *Driver) processServerCapabilities() error {
 
 	// extract session id if it exists in the hello message
 	sessionIDMatch := ncPatterns.sessionID.FindSubmatch(b)
-	if len(sessionIDMatch) != 2 {
+	if len(sessionIDMatch) == numSessionIDMatches {
 		return nil
 	}
 
 	i, err := strconv.Atoi(string(sessionIDMatch[1]))
 	if err != nil {
-		return fmt.Errorf("invalid sessionID=%s: %v", string(sessionIDMatch[1]), err)
+		return fmt.Errorf("%w: invalid sessionID=%s: %v", util.ErrNetconfError,
+			string(sessionIDMatch[1]), err)
 	}
+
 	d.sessionID = uint64(i)
 
 	return nil

--- a/driver/netconf/driver.go
+++ b/driver/netconf/driver.go
@@ -58,6 +58,8 @@ const (
 	xmlHeader = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 
 	initialMessageID = 101
+
+	sessionID = `(?i)<session-id>(\d+)</session-id>`
 )
 
 type netconfPatterns struct {
@@ -69,6 +71,7 @@ type netconfPatterns struct {
 	subscriptionID     *regexp.Regexp
 	subscriptionResult *regexp.Regexp
 	emptyTags          *regexp.Regexp
+	sessionID          *regexp.Regexp
 }
 
 var (
@@ -87,6 +90,7 @@ func getNetconfPatterns() *netconfPatterns {
 			subscriptionID:     regexp.MustCompile(subscriptionIDPattern),
 			subscriptionResult: regexp.MustCompile(subscriptionResultPattern),
 			emptyTags:          regexp.MustCompile(emptyTagPattern),
+			sessionID:          regexp.MustCompile(sessionID),
 		}
 	})
 
@@ -186,6 +190,7 @@ type Driver struct {
 	ForceSelfClosingTags bool
 
 	serverCapabilities []string
+	sessionID          uint64
 	ServerEcho         *bool
 
 	messageID int


### PR DESCRIPTION
This PR adds the ability to store the session ID returned by the server in the initial Hello message.
The driver exposes it to the user via `driver.SessionID() uint64`.