### PR TITLE
Add run shell definition to ios-xr

### DIFF
--- a/assets/platforms/cisco_iosxr.yaml
+++ b/assets/platforms/cisco_iosxr.yaml
@@ -27,6 +27,16 @@ default:
       escalate: 'configure exclusive'
       escalate-auth: false
       escalate-prompt:
+    run:
+      name: 'run'
+      # match [xr-vm_node0_RP0_CPU0:~]$ (Cisco NC55XX)
+      # match [node0_RP0_CPU0:~]$ (Cisco 8000)
+      pattern: '(?im)^\[[^]]+\]\$\s*$'
+      previous-priv: 'exec'
+      deescalate: 'logout'
+      escalate: 'run'
+      escalate-auth: false
+      escalate-prompt:
   default-desired-privilege-level: 'exec'
   failed-when-contains:
     - '% Ambiguous command'


### PR DESCRIPTION
Add  support for run shell privilege on Cisco IOS-XR.

Run shell can be required to move files around (my use-case was setting my own certificates/ca for grpc).

More details in: https://github.com/scrapli/scrapligo/issues/160.
