### PR TITLE
fix: update comments to update option.WithPrivilegeLevel to opoptions…

### DIFF
--- a/examples/network_driver/sending_configs/main.go
+++ b/examples/network_driver/sending_configs/main.go
@@ -41,7 +41,7 @@ func main() {
 	// "configuration" privilege level, if your platform does *not* have a "configuration" priv
 	// level things will fail! if there is an alternative to configuration (such as "exclusive"),
 	// you can explicitly execute configs in that privilege level with the
-	// `options.WithPrivilegeLevel` option.
+	// `opoptions.WithPrivilegeLevel` option.
 	r, err := d.SendConfigs([]string{"interface loopback999", "description tacocat"})
 	if err != nil {
 		fmt.Printf("failed to open driver; error: %+v\n", err)


### PR DESCRIPTION
option.WithPrivilegeLevels is the option used by the driver, and opoptions.WithPrivilegeLevel is the option used when sending commands, which can easily lead to ambiguity.