### PR TITLE
Add support for Huawei VRP CLI

### DIFF
--- a/assets/platforms/huawei_vrp.yaml
+++ b/assets/platforms/huawei_vrp.yaml
@@ -1,0 +1,38 @@
+---
+platform-type: 'huawei_vrp'
+default:
+  driver-type: 'network'
+  privilege-levels:
+    user-view:
+      name: 'user-view'
+      pattern: '(?im)^<[\w.\-@/:]{1,63}>$'
+      previous-priv:
+      deescalate:
+      escalate:
+      escalate-auth: false
+      escalate-prompt:
+    system-view:
+      name: 'system-view'
+      pattern: '(?im)^[[\w.\-@/:]{1,63}]$'
+      previous-priv: 'user-view'
+      deescalate: 'quit'
+      escalate: 'system-view'
+      escalate-auth: false
+      escalate-prompt:
+  default-desired-privilege-level: 'user-view'
+  failed-when-contains:
+    - 'Error: Unrecognized command'
+    - 'Error: Wrong parameter'
+      # missing whitespace is intentional below
+    - 'Error:Ambiguous command'
+    - 'Error:Incomplete command'
+  textfsm-platform: 'huawei_vrp' # ignored in go because no ntc-templates
+  network-on-open:
+    - operation: 'acquire-priv' # targets default desired priv by default
+    - operation: 'driver.send-command'
+      command: 'screen-length 0 temporary'
+  network-on-close:
+    - operation: 'acquire-priv'
+    - operation: 'channel.write'
+      input: 'quit'
+    - operation: 'channel.return'


### PR DESCRIPTION
Add support for Huawei VRP CLI. A CLI session looks like this:
```
[wilwij@mira ~]$ ssh huawei-development-sw1.example.net

User Authentication
(wiwi@huawei-development-sw1.example.net) Password: 

Info: The max number of VTY users is 10, and the number
      of current VTY users on line is 1.
      The current login time is 2024-01-10 08:41:02+01:00.
<huawei-development-sw1>
<huawei-development-sw1>
<huawei-development-sw1>
<huawei-development-sw1>disp port vlan gig
<huawei-development-sw1>disp port vlan gi0/0/20
Port                        Link Type    PVID  Trunk VLAN List
-------------------------------------------------------------------------------
GigabitEthernet0/0/20       desirable    1     1-4094
<huawei-development-sw1>system-vi
Enter system view, return user view with Ctrl+Z.
[huawei-development-sw1]interface gi0/0/20
[huawei-development-sw1-GigabitEthernet0/0/20]?
gigabitethernet-l2 interface view commands:
  als                        Set automatic laser shutdown 
  am                         Unidirectional isolation
  arp                        Address Resolution Protocol
  arp-fake                   ARP fake entry
  arp-limit                  Limit the number of learnt ARP
  arp-miss                   ARP Miss
  authentication             Authentication
  auto                       Auto negotiates port mode 
  bandwidth                  Specify mib-referenced bandwidth of the interface
  broadcast-suppression      Set broadcast flow suppression
  carrier                    Set carrier function
  cfm                        Connectivity fault management
  clear                      Clear
  collect                    Collect TOPN information
  combo-port                 Set combo type 
  configuration              Configuration interlock
  dei                        Specify dei as drop precedence 
  description                Specify interface description
  dhcp                       Dynamic host configure protocol
  dhcpv6                     Dynamic host configure protocol for IPv6
  display                    Display current system information
  dldp                       Device link detection protocol
  dot1x                      802.1x and mac-authen configuration information
  duplex                     Configure duplex operation mode 
                                          

[huawei-development-sw1-GigabitEthernet0/0/20]quit
[huawei-development-sw1]quit
<huawei-development-sw1>disp port gi0/0/40
                                  ^
Error: Unrecognized command found at '^' position.
<huawei-development-sw1>quit
Info: The max number of VTY users is 10, and the number
      of current VTY users on line is 0.Connection to huawei-development-sw1.example.net closed.
```