### PR TITLE
Return an error on channel read when the transport has finished

### DIFF
--- a/channel/read.go
+++ b/channel/read.go
@@ -122,6 +122,10 @@ func (c *Channel) Read() ([]byte, error) {
 	default:
 	}
 
+	if c.readLoopExited {
+		return nil, util.ErrConnectionError
+	}
+
 	b := c.Q.Dequeue()
 
 	if b == nil {


### PR DESCRIPTION
I stumbled upon an issue where my transport terminated, but the error was not propagated to the Read() and thus I was timeouting instead of erroring right away.