### PR TITLE
Add Option to Exclude XML Header for NETCONF Messages

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.61
           args: --timeout 5m
 
       - name: install gotestsum

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -123,4 +123,4 @@ output:
   uniq-by-line: false
 
 service:
-  golangci-lint-version: 1.60.x
+  golangci-lint-version: 1.61.x

--- a/driver/netconf/capabilities.go
+++ b/driver/netconf/capabilities.go
@@ -118,7 +118,7 @@ func (d *Driver) processServerCapabilities() error {
 			string(sessionIDMatch[1]), err)
 	}
 
-	d.sessionID = uint64(i)
+	d.sessionID = uint64(i) //nolint:gosec
 
 	return nil
 }

--- a/driver/netconf/driver.go
+++ b/driver/netconf/driver.go
@@ -188,6 +188,7 @@ type Driver struct {
 	SelectedVersion  string
 
 	ForceSelfClosingTags bool
+	ExcludeHeader        bool
 
 	serverCapabilities []string
 	sessionID          uint64

--- a/driver/netconf/message.go
+++ b/driver/netconf/message.go
@@ -18,7 +18,11 @@ type serializedInput struct {
 	framedXML []byte
 }
 
-func (m *message) serialize(v string, forceSelfClosingTags bool, excludeHeader bool) (*serializedInput, error) {
+func (m *message) serialize(
+	v string,
+	forceSelfClosingTags,
+	excludeHeader bool,
+) (*serializedInput, error) {
 	serialized := &serializedInput{}
 
 	msg, err := xml.Marshal(m)

--- a/driver/netconf/message.go
+++ b/driver/netconf/message.go
@@ -18,7 +18,7 @@ type serializedInput struct {
 	framedXML []byte
 }
 
-func (m *message) serialize(v string, forceSelfClosingTags bool) (*serializedInput, error) {
+func (m *message) serialize(v string, forceSelfClosingTags bool, excludeHeader bool) (*serializedInput, error) {
 	serialized := &serializedInput{}
 
 	msg, err := xml.Marshal(m)
@@ -26,7 +26,9 @@ func (m *message) serialize(v string, forceSelfClosingTags bool) (*serializedInp
 		return nil, err
 	}
 
-	msg = append([]byte(xmlHeader), msg...)
+	if !excludeHeader {
+		msg = append([]byte(xmlHeader), msg...)
+	}
 
 	if forceSelfClosingTags {
 		msg = ForceSelfClosingTags(msg)

--- a/driver/netconf/rpc.go
+++ b/driver/netconf/rpc.go
@@ -35,7 +35,7 @@ func (d *Driver) sendRPC(
 		d.Logger.Debug("ForceSelfClosingTags is true, enforcing...")
 	}
 
-	serialized, err := m.serialize(d.SelectedVersion, d.ForceSelfClosingTags)
+	serialized, err := m.serialize(d.SelectedVersion, d.ForceSelfClosingTags, d.ExcludeHeader)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/options/netconf.go
+++ b/driver/options/netconf.go
@@ -45,3 +45,19 @@ func WithNetconfForceSelfClosingTags() util.Option {
 		return nil
 	}
 }
+
+// WithNetconfExcludeHeader excludes the XML header from the NETCONF message.
+// This is useful for devices that do not support the XML header.
+func WithNetconfExcludeHeader() util.Option {
+	return func(o interface{}) error {
+		d, ok := o.(*netconf.Driver)
+
+		if !ok {
+			return util.ErrIgnoredOption
+		}
+
+		d.ExcludeHeader = true
+
+		return nil
+	}
+}


### PR DESCRIPTION
#### Title:
Add Option to Exclude XML Header for NETCONF Messages

#### Description:
This pull request introduces an option to exclude the XML header from NETCONF messages. The motivation behind this change stems from an issue encountered with certain devices, such as Calix's earlier platforms, where the inclusion of the XML header causes the system to misinterpret the message as an invalid XML document. This update provides flexibility by allowing users to disable the header when necessary.

#### Changes:
- **Added a new field** `ExcludeHeader` in the `Driver` struct to control whether the XML header is prepended to NETCONF messages.
- **Updated the `serialize` function** to check the `ExcludeHeader` flag before appending the XML header. If `ExcludeHeader` is `true`, the header is omitted.
- **Updated the `sendRPC` function** to pass the `ExcludeHeader` flag during serialization.
- **Added a new option** `WithNetconfExcludeHeader` in the `options/netconf.go` file to provide a user-friendly interface for enabling this behavior.

#### Reason for Change:
The addition of the `ExcludeHeader` flag resolves issues with NETCONF messages being rejected by certain devices that expect raw XML content without the standard XML declaration header.

#### Impact:
- No changes to the default behavior. By default, the XML header will continue to be included unless explicitly disabled using the new option.
- Devices that do not properly handle XML headers can now be supported by using the new `WithNetconfExcludeHeader` option.