### PR TITLE
Added ~ in regex for system-view

### DIFF
--- a/assets/platforms/huawei_vrp.yaml
+++ b/assets/platforms/huawei_vrp.yaml
@@ -13,7 +13,7 @@ default:
       escalate-prompt:
     system-view:
       name: 'system-view'
-      pattern: '(?im)^[[\w.\-@/:]{1,63}]$'
+      pattern: '(?im)^[[\w.\-@/:~]{1,63}]$'
       previous-priv: 'user-view'
       deescalate: 'quit'
       escalate: 'system-view'


### PR DESCRIPTION
Adding tilde ~ as a regex character for system-view in Huawei nodes as they typically begin with that.