### PR TITLE
Adding ~ and * as valid characters in the prompt regex for Huawei

### DIFF
--- a/assets/platforms/huawei_vrp.yaml
+++ b/assets/platforms/huawei_vrp.yaml
@@ -13,7 +13,7 @@ default:
       escalate-prompt:
     system-view:
       name: 'system-view'
-      pattern: '(?im)^[[\w.\-@/:~]{1,63}]$'
+      pattern: '(?im)^[[\w.\-@/:~*]{1,63}]$'
       previous-priv: 'user-view'
       deescalate: 'quit'
       escalate: 'system-view'

--- a/assets/platforms/huawei_vrp.yaml
+++ b/assets/platforms/huawei_vrp.yaml
@@ -13,7 +13,7 @@ default:
       escalate-prompt:
     system-view:
       name: 'system-view'
-      pattern: '(?im)^[[\w.\-@/:]{1,63}]$'
+      pattern: '(?im)^[[\w.\-@/:~]{1,63}]$'
       previous-priv: 'user-view'
       deescalate: 'quit'
       escalate: 'system-view'


### PR DESCRIPTION
Adding ~ and * as valid characters in the prompt regex for Huawei since they are common in the NE40 platform.
See https://support.huawei.com/enterprise/en/doc/EDOC1100278537/f3e2de1e/configuration for examples.