### PR TITLE
Update huawei_vrp.yaml to support configuration functions

### DIFF
--- a/assets/platforms/huawei_vrp.yaml
+++ b/assets/platforms/huawei_vrp.yaml
@@ -11,9 +11,9 @@ default:
       escalate:
       escalate-auth: false
       escalate-prompt:
-    system-view:
-      name: 'system-view'
-      pattern: '(?im)^[[\w.\-@/:]{1,63}]$'
+    configuration:
+      name: 'configuration'
+      pattern: '(?im)^[[\w.\-@/:~*]{1,63}]$'
       previous-priv: 'user-view'
       deescalate: 'quit'
       escalate: 'system-view'


### PR DESCRIPTION
Changed the privilege-levels name for system-view to configuration and the name to configuration to work seamlessly with existing functions.  
Also added special characters that's common in the NE40 VRP platform to match prompt more consistently. 
Have tested this on my end towards actual routers and it seems to work fine.