### PR TITLE
fix Goroutine leak due to stuck send on channel on timeouts

### DIFF
--- a/channel/read.go
+++ b/channel/read.go
@@ -227,7 +227,7 @@ func (c *Channel) ReadUntilPrompt(ctx context.Context) ([]byte, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, nil
+			return nil, ctx.Err()
 		default:
 		}
 
@@ -261,7 +261,7 @@ func (c *Channel) ReadUntilAnyPrompt(
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, nil
+			return nil, ctx.Err()
 		default:
 		}
 

--- a/channel/sendinput.go
+++ b/channel/sendinput.go
@@ -2,6 +2,8 @@ package channel
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/scrapli/scrapligo/util"
@@ -85,6 +87,15 @@ func (c *Channel) SendInputB(input []byte, opts ...util.Option) ([]byte, error) 
 
 	r := <-cr
 	if r.err != nil {
+		if errors.Is(r.err, context.DeadlineExceeded) {
+			c.l.Critical("channel timeout sending input to device")
+
+			return nil, fmt.Errorf(
+				"%w: channel timeout sending input to device",
+				util.ErrTimeoutError,
+			)
+		}
+
 		return nil, r.err
 	}
 

--- a/channel/sendinput.go
+++ b/channel/sendinput.go
@@ -2,9 +2,7 @@ package channel
 
 import (
 	"context"
-	"fmt"
 	"regexp"
-	"time"
 
 	"github.com/scrapli/scrapligo/util"
 )
@@ -26,7 +24,7 @@ func (c *Channel) SendInputB(input []byte, opts ...util.Option) ([]byte, error) 
 
 	cr := make(chan *result)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), c.GetTimeout(op.Timeout))
 
 	// we'll call cancel no matter what, either the read goroutines finished nicely in which case it
 	// doesnt matter, or we hit the timer and the cancel will stop the reading
@@ -72,6 +70,8 @@ func (c *Channel) SendInputB(input []byte, opts ...util.Option) ([]byte, error) 
 
 			if readErr != nil {
 				cr <- &result{b: b, err: readErr}
+
+				return
 			}
 
 			b = append(b, nb...)
@@ -83,20 +83,12 @@ func (c *Channel) SendInputB(input []byte, opts ...util.Option) ([]byte, error) 
 		}
 	}()
 
-	timer := time.NewTimer(c.GetTimeout(op.Timeout))
-
-	select {
-	case r := <-cr:
-		if r.err != nil {
-			return nil, r.err
-		}
-
-		return r.b, nil
-	case <-timer.C:
-		c.l.Critical("channel timeout sending input to device")
-
-		return nil, fmt.Errorf("%w: channel timeout sending input to device", util.ErrTimeoutError)
+	r := <-cr
+	if r.err != nil {
+		return nil, r.err
 	}
+
+	return r.b, nil
 }
 
 // SendInput sends the input string to the target device. Any bytes output is returned.


### PR DESCRIPTION
Hello everyone,

we're using `scrapligo` to gather information from devices in an API. However we noticed an increasing number of Goroutines due to some devices where the input is running into timeouts.

With pprof we saw the following goroutines hanging:

```
# DEBUG=1

goroutine profile: total 55
16 @ 0x4731ae 0x407c6d 0x4078d7 0x8d633c 0x47b2c1
#       0x8d633b        [github.com/scrapli/scrapligo/channel](http://github.com/scrapli/scrapligo/channel).(*Channel).SendInputB.func1+0x4fb  /src/vendor/[github.com/scrapli/scrapligo/channel/sendinput.go:80](http://github.com/scrapli/scrapligo/channel/sendinput.go:80)
```

```
# DEBUG=2

goroutine 35769 [chan send, 407 minutes]:
[github.com/scrapli/scrapligo/channel](http://github.com/scrapli/scrapligo/channel).(*Channel).SendInputB.func1()
        /src/vendor/[github.com/scrapli/scrapligo/channel/sendinput.go:80](http://github.com/scrapli/scrapligo/channel/sendinput.go:80) +0x4fc
created by [github.com/scrapli/scrapligo/channel](http://github.com/scrapli/scrapligo/channel).(*Channel).SendInputB in goroutine 33303
        /src/vendor/[github.com/scrapli/scrapligo/channel/sendinput.go:35](http://github.com/scrapli/scrapligo/channel/sendinput.go:35) +0x2f4
 
goroutine 101718 [chan send, 48 minutes]:
[github.com/scrapli/scrapligo/channel](http://github.com/scrapli/scrapligo/channel).(*Channel).SendInputB.func1()
        /src/vendor/[github.com/scrapli/scrapligo/channel/sendinput.go:80](http://github.com/scrapli/scrapligo/channel/sendinput.go:80) +0x4fc
created by [github.com/scrapli/scrapligo/channel](http://github.com/scrapli/scrapligo/channel).(*Channel).SendInputB in goroutine 99320
        /src/vendor/[github.com/scrapli/scrapligo/channel/sendinput.go:35](http://github.com/scrapli/scrapligo/channel/sendinput.go:35) +0x2f4
```

To fix the issue I decided to ditch the timer for a context with timeout. This makes it possible to completely get rid of the select and make sure that the channel is always read. I also added an additional return statement, so that in rare cases the goroutine does not try to write into the channel twice.

Please let me know if you have any suggestions for improvement.

Thanks!

Sebastian