### PR TITLE
fix leaks in SendWithCallbacks function

### DIFF
--- a/driver/generic/sendwithcallbacks.go
+++ b/driver/generic/sendwithcallbacks.go
@@ -172,6 +172,7 @@ func (d *Driver) handleCallbacks(
 
 	go func() {
 		defer close(c)
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -182,6 +183,7 @@ func (d *Driver) handleCallbacks(
 					c <- &callbackResult{
 						err: err,
 					}
+
 					return
 				}
 
@@ -197,6 +199,7 @@ func (d *Driver) handleCallbacks(
 							fb:        fb,
 							err:       nil,
 						}
+
 						return
 					}
 				}
@@ -209,6 +212,7 @@ func (d *Driver) handleCallbacks(
 		if r.err != nil {
 			return nil, r.err
 		}
+
 		return d.executeCallback(r.i, r.callbacks, r.b, r.fb, timeout)
 	case <-ctx.Done():
 		return nil, fmt.Errorf("%w: timeout handling callbacks", util.ErrTimeoutError)


### PR DESCRIPTION
Greetings, came across a heavy CPU load for a constant time, saw a recent PR that goroutine leaks have been fixed. With perf analysed the situation and saw that there are indeed goroutine leaks in SendWithCallbacks. Unlike a simple leak, where we have dead goroutines and degrade the scheduler, these goroutines are still engaged in a perpetual check of the CallbacksPattern, which resulted in 100% CPU utilisation. I had my CPU running at 100% like that for a week, even though it should have been doing no work at all. I will also attach a screenshot with perf, that in the rest of the programme all the load is on the check.

As for backwards compatibility, I don't think I had any problems with the programme hanging, timeout worked fine

<img width="1080" alt="Screenshot 2024-12-01 at 01 15 00" src="https://github.com/user-attachments/assets/0cc8fe09-a870-46d2-9c7c-98881803c307">

