### PR TITLE
Fix sendinput hanging forever when connection is blocked

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -76,6 +76,7 @@ func prepareChannel(
 	t *testing.T,
 	testName,
 	payloadFile string,
+	chanOpts ...util.Option,
 ) (*channel.Channel, *transport.File) {
 	l, _ := logging.NewInstance()
 
@@ -90,7 +91,7 @@ func prepareChannel(
 		t.Errorf("%s: encountered error creating File Transport, error: %s", testName, err)
 	}
 
-	c, err := channel.NewChannel(l, transportObj)
+	c, err := channel.NewChannel(l, transportObj, chanOpts...)
 	if err != nil {
 		t.Errorf("%s: encountered error creating Channel, error: %s", testName, err)
 	}

--- a/channel/read.go
+++ b/channel/read.go
@@ -161,7 +161,7 @@ func (c *Channel) ReadAll() ([]byte, error) {
 }
 
 // ReadUntilFuzzy reads until a fuzzy match of the input is found.
-func (c *Channel) ReadUntilFuzzy(b []byte) ([]byte, error) {
+func (c *Channel) ReadUntilFuzzy(ctx context.Context, b []byte) ([]byte, error) {
 	if len(b) == 0 {
 		return nil, nil
 	}
@@ -169,6 +169,12 @@ func (c *Channel) ReadUntilFuzzy(b []byte) ([]byte, error) {
 	var rb []byte
 
 	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		nb, err := c.Read()
 		if err != nil {
 			return nil, err
@@ -193,10 +199,16 @@ func (c *Channel) ReadUntilFuzzy(b []byte) ([]byte, error) {
 
 // ReadUntilExplicit reads bytes out of the channel Q object until the bytes b are seen in the
 // output. Once the bytes are seen all read bytes are returned.
-func (c *Channel) ReadUntilExplicit(b []byte) ([]byte, error) {
+func (c *Channel) ReadUntilExplicit(ctx context.Context, b []byte) ([]byte, error) {
 	var rb []byte
 
 	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		nb, err := c.Read()
 		if err != nil {
 			return nil, err

--- a/channel/sendinput_test.go
+++ b/channel/sendinput_test.go
@@ -135,7 +135,7 @@ func TestSendInput(t *testing.T) {
 	}
 }
 
-func TestScrapligoSendCommandErrorTimeout(t *testing.T) {
+func TestSendCommandTimeout(t *testing.T) {
 	input := readFile(t, "send-input-timeout-in.txt")
 
 	c, _ := prepareChannel(

--- a/channel/sendinput_test.go
+++ b/channel/sendinput_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/scrapli/scrapligo/driver/opoptions"
+	"github.com/scrapli/scrapligo/driver/options"
 
 	"github.com/scrapli/scrapligo/util"
 
@@ -130,5 +132,32 @@ func TestSendInput(t *testing.T) {
 		f := testSendInput(testName, testCase)
 
 		t.Run(testName, f)
+	}
+}
+
+func TestScrapligoSendCommandErrorTimeout(t *testing.T) {
+	input := readFile(t, "send-input-timeout-in.txt")
+
+	c, _ := prepareChannel(
+		t,
+		t.Name(),
+		"send-input-timeout-out.txt",
+		options.WithTimeoutOps(1*time.Millisecond),
+	)
+	_, err := c.SendInput(string(input))
+
+	if err == nil {
+		t.Fatalf("%s: expecting an error but got none", t.Name())
+	}
+
+	expectedErr := "errTimeoutError: channel timeout sending input to device"
+
+	if err.Error() != expectedErr {
+		t.Fatalf(
+			"%s: actual and expected errors do not match\nactual: %s\nexpected:%s",
+			t.Name(),
+			err.Error(),
+			expectedErr,
+		)
 	}
 }

--- a/channel/sendinteractive.go
+++ b/channel/sendinteractive.go
@@ -24,7 +24,7 @@ func (c *Channel) sendInteractive(
 	cr chan *result,
 	events []*SendInteractiveEvent,
 	op *OperationOptions,
-	readUntilF func(b []byte) ([]byte, error),
+	readUntilF func(ctx context.Context, b []byte) ([]byte, error),
 ) {
 	defer close(cr)
 
@@ -48,7 +48,7 @@ func (c *Channel) sendInteractive(
 		if e.ChannelResponse != "" && !e.HideInput {
 			var nb []byte
 
-			nb, err = readUntilF([]byte(e.ChannelInput))
+			nb, err = readUntilF(ctx, []byte(e.ChannelInput))
 			if err != nil {
 				cr <- &result{b: nil, err: err}
 

--- a/channel/test-fixtures/send-input-timeout-in.txt
+++ b/channel/test-fixtures/send-input-timeout-in.txt
@@ -1,0 +1,1 @@
+show running-config

--- a/channel/test-fixtures/send-input-timeout-out.txt
+++ b/channel/test-fixtures/send-input-timeout-out.txt
@@ -1,0 +1,3 @@
+RP/0/RP0/CPU0:iosxr75#terminal width 512
+RP/0/RP0/CPU0:iosxr75#terminal length 0
+RP/0/RP0/CPU0:iosxr75#show running-co


### PR DESCRIPTION
Hello

We have an issue since we bumped from `v1.3.2` to `v1.3.3` in our unit tests.

We have a test where we send a command to a device and expect it to fail with a timeout (we try to simulate a device experiencing a connection issue and not responding anymore). The test was working before and now hang infinitely.

I reproduced the test case in `v1.3.2` where we send the command `show running-config` and Scrapligo can only read back a part of the output.

Here [the test case executed against commit `v1.3.2` (commit: `a6c4329`)](https://github.com/scrapli/scrapligo/compare/v1.3.2...kdisneur:scrapligo:v1.3.2_testcase?expand=1)
```
git checkout v1.3.2_testcase
go test -count 1 ./channel -run TestScrapligoSendCommandErrorTimeout
ok      github.com/scrapli/scrapligo/channel    0.006s
```

Here [the same test case executed against commit `v1.3.3` (commit: `7ea22c0`)](https://github.com/scrapli/scrapligo/compare/v1.3.3...kdisneur:scrapligo:v1.3.3_testcase?expand=1)

```
git checkout v1.3.3_testcase
go test -count 1 ./channel -run TestScrapligoSendCommandErrorTimeout
^Csignal: interrupt
FAIL    github.com/scrapli/scrapligo/channel    175.238s
FAIL
```

I think this is caused by this call to [`r := <-cr`](https://github.com/scrapli/scrapligo/blob/7ea22c08c868905d3fea2a9b76b3cf4a9a16376d/channel/sendinput.go#L88) because it doesn't take into account the timeout of the context.
I don't know / understand the full implication of my proposal but this pull-request would fix our specific use case:

```
git checkout v1.3.3_fix
go test -count 1 ./channel -run TestScrapligoSendCommandErrorTimeout
ok      github.com/scrapli/scrapligo/channel    0.006s
```