### PR TITLE
Harmonize privilege level names for VRP and Comware

### DIFF
--- a/assets/platforms/hp_comware.yaml
+++ b/assets/platforms/hp_comware.yaml
@@ -3,23 +3,23 @@ platform-type: 'hp_comware'
 default:
   driver-type: 'network'
   privilege-levels:
-    user-view:
-      name: 'user-view'
+    exec:
+      name: 'exec'
       pattern: '(?im)^<[\w.\-@/:]{1,63}>$'
       previous-priv:
       deescalate:
       escalate:
       escalate-auth: false
       escalate-prompt:
-    system-view:
-      name: 'system-view'
+    configuration:
+      name: 'configuration'
       pattern: '(?im)^[[\w.\-@/:]{1,63}]$'
-      previous-priv: 'user-view'
+      previous-priv: 'exec'
       deescalate: 'quit'
       escalate: 'system-view'
       escalate-auth: false
       escalate-prompt:
-  default-desired-privilege-level: 'user-view'
+  default-desired-privilege-level: 'exec'
   failed-when-contains:
     - '% Unrecognized command'
     - '% Ambiguous command'

--- a/assets/platforms/huawei_vrp.yaml
+++ b/assets/platforms/huawei_vrp.yaml
@@ -3,23 +3,23 @@ platform-type: 'huawei_vrp'
 default:
   driver-type: 'network'
   privilege-levels:
-    user-view:
-      name: 'user-view'
+    exec:
+      name: 'exec'
       pattern: '(?im)^<[\w.\-@/:]{1,63}>$'
       previous-priv:
       deescalate:
       escalate:
       escalate-auth: false
       escalate-prompt:
-    system-view:
-      name: 'system-view'
+    configuration:
+      name: 'configuration'
       pattern: '(?im)^[[\w.\-@/:]{1,63}]$'
-      previous-priv: 'user-view'
+      previous-priv: 'exec'
       deescalate: 'quit'
       escalate: 'system-view'
       escalate-auth: false
       escalate-prompt:
-  default-desired-privilege-level: 'user-view'
+  default-desired-privilege-level: 'exec'
   failed-when-contains:
     - 'Error: Unrecognized command'
     - 'Error: Wrong parameter'


### PR DESCRIPTION
When I added the VRP model definition almost a year ago I did not use the same privilege levels as the other models for some reason. Having the same for all models as far as possible makes sense as an abstraction layer IMO. Also did the same for HP Comware.