### PR TITLE
Bug with handleCallbacks nil channel reading.

### DIFF
--- a/driver/generic/sendwithcallbacks.go
+++ b/driver/generic/sendwithcallbacks.go
@@ -209,9 +209,9 @@ func (d *Driver) handleCallbacks(
 
 	select {
 	case r := <-c:
-        if r == nil {
-            return
-        }
+		if r == nil {
+			return nil, fmt.Errorf("%w: reading from closed channel during callbacks", util.ErrTimeoutError)
+		}
 
 		if r.err != nil {
 			return nil, r.err


### PR DESCRIPTION
There was an issue with catching the situation in person and being able to replay the race several times (running on a device with limited resources). Case Description:
1) ctx.Timeout is triggered and goroutine is closed
2) defer is triggered and channel is closed
3) two situations are triggered in the main function select:
3.1) ctx.timeout is triggered and everything will work correctly.
3.2) reading from the channel will work (because closing also triggers select) and we will get a panic on reading r.err because r will be nil.
