### PR TITLE
fix: Typo in error message of network driver

### DIFF
--- a/driver/network/driver.go
+++ b/driver/network/driver.go
@@ -43,7 +43,7 @@ func NewDriver(
 	if d.DefaultDesiredPriv == "" || len(d.PrivilegeLevels) == 0 {
 		return nil, fmt.Errorf(
 			"%w: no default desired privilege level and/or privilege levels provided, "+
-				"these are required with 'netework' driver",
+				"these are required with 'network' driver",
 			util.ErrBadOption,
 		)
 	}


### PR DESCRIPTION
Fixes the wrong spelled "network" in the error message of the network driver.