### PR TITLE
fix: update regex pattern in getPromptPattern function

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -37,7 +37,7 @@ var (
 
 func getPromptPattern() *regexp.Regexp {
 	promptPatternOnce.Do(func() {
-		promptPattern = regexp.MustCompile(`(?im)^[a-z\d.\-@()/:]{1,48}[#>$]\s*$`)
+		promptPattern = regexp.MustCompile(`(?im)^[a-z\d.\-@()/:_]{1,48}[#>$]\s*$`)
 	})
 
 	return promptPattern


### PR DESCRIPTION
**Changes:**
- Adds `_` (underscore) support

**Reason**
Cisco IOS XR allows underscores in hostnames (e.g. my_sweet_rtr), even though RFCs disallow them. Current prompt matcher fails on such cases. This PR adds `_` to the hostname regex so prompts with underscores are parsed correctly.