### PR TITLE
Add '% Invalid command' to Cisco NXOS fail-when-contains list.

### DIFF
--- a/assets/platforms/cisco_nxos.yaml
+++ b/assets/platforms/cisco_nxos.yaml
@@ -44,6 +44,7 @@ default:
     - '% Incomplete command'
     - '% Invalid input detected'
     - '% Unknown command'
+    - '% Invalid command'
     - 'ERROR:'
   textfsm-platform: 'cisco_nxos' # ignored in go because no ntc-templates
   network-on-open:


### PR DESCRIPTION
In Cisco NX-OS, when a particular feature is disabled, trying to run a relevant command results in an invalid command output.

Steps to reproduce in the public NX-OS sandbox:
```
conf t

no feature eigrp
```
and then:
```
nxos# show run eigrp
                ^
% Invalid command at '^' marker.
```

This was not present in the NX-OS platform yaml but I thought it makes sense to have it. Let me know if any tests need to be updated.