### PR TITLE
Add in-memory SSH private key and known hosts support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,9 @@ private/
 # coverage
 cover.out
 
+# direnv
+.envrc
+.envrc.local
+
 # where we mount stuff when running clab bits
 .clab

--- a/internal/ffi.go
+++ b/internal/ffi.go
@@ -41,6 +41,8 @@ type driverOptions struct {
 		usernameLen             uintptr
 		password                uintptr
 		passwordLen             uintptr
+		privateKey              uintptr
+		privateKeyLen           uintptr
 		privateKeyPath          uintptr
 		privateKeyPathLen       uintptr
 		privateKeyPassphrase    uintptr
@@ -72,6 +74,8 @@ type driverOptions struct {
 			overrideOpenArgsLen uintptr
 			sshConfigPath       uintptr
 			sshConfigPathLen    uintptr
+			knownHosts          uintptr
+			knownHostsLen       uintptr
 			knownHostsPath      uintptr
 			knownHostsPathLen   uintptr
 			enableStrictKey     *bool
@@ -80,6 +84,8 @@ type driverOptions struct {
 		}
 
 		ssh2 struct {
+			knownHosts                       uintptr
+			knownHostsLen                    uintptr
 			knownHostsPath                   uintptr
 			knownHostsPathLen                uintptr
 			libssh2Trace                     *bool

--- a/internal/options.go
+++ b/internal/options.go
@@ -199,6 +199,7 @@ type AuthOptions struct {
 	Username string
 	Password string
 
+	PrivateKey           string
 	PrivateKeyPath       string
 	PrivateKeyPassphrase string
 
@@ -225,6 +226,11 @@ func (o *AuthOptions) apply(opts *driverOptions) {
 	if o.Password != "" {
 		opts.auth.password = uintptr(unsafe.Pointer(&[]byte(o.Password)[0]))
 		opts.auth.passwordLen = uintptr(len(o.Password))
+	}
+
+	if o.PrivateKey != "" {
+		opts.auth.privateKey = uintptr(unsafe.Pointer(&[]byte(o.PrivateKey)[0]))
+		opts.auth.privateKeyLen = uintptr(len(o.PrivateKey))
 	}
 
 	if o.PrivateKeyPath != "" {
@@ -305,6 +311,7 @@ type TransportBinOptions struct {
 	ExtraOpenArgs    string
 	OverrideOpenArgs string
 	SSHConfigPath    string
+	KnownHosts       string
 	KnownHostsPath   string
 	EnableStrictKey  bool
 	TermHeight       *uint16
@@ -334,6 +341,11 @@ func (o *TransportBinOptions) apply(opts *driverOptions) {
 		opts.transport.bin.sshConfigPathLen = uintptr(len(o.SSHConfigPath))
 	}
 
+	if o.KnownHosts != "" {
+		opts.transport.bin.knownHosts = uintptr(unsafe.Pointer(&[]byte(o.KnownHosts)[0]))
+		opts.transport.bin.knownHostsLen = uintptr(len(o.KnownHosts))
+	}
+
 	if o.KnownHostsPath != "" {
 		opts.transport.bin.knownHostsPath = uintptr(unsafe.Pointer(&[]byte(o.KnownHostsPath)[0]))
 		opts.transport.bin.knownHostsPathLen = uintptr(len(o.KnownHostsPath))
@@ -354,6 +366,7 @@ func (o *TransportBinOptions) apply(opts *driverOptions) {
 
 // TransportSSH2Options holds (lib)"ssh2" transport specific options.
 type TransportSSH2Options struct {
+	KnownHosts     string
 	KnownHostsPath string
 	LibSSH2Trace   bool
 
@@ -368,6 +381,11 @@ type TransportSSH2Options struct {
 }
 
 func (o *TransportSSH2Options) apply(opts *driverOptions) {
+	if o.KnownHosts != "" {
+		opts.transport.ssh2.knownHosts = uintptr(unsafe.Pointer(&[]byte(o.KnownHosts)[0]))
+		opts.transport.ssh2.knownHostsLen = uintptr(len(o.KnownHosts))
+	}
+
 	if o.KnownHostsPath != "" {
 		opts.transport.ssh2.knownHostsPath = uintptr(unsafe.Pointer(&[]byte(o.KnownHostsPath)[0]))
 		opts.transport.ssh2.knownHostsPathLen = uintptr(len(o.KnownHostsPath))

--- a/options/auth.go
+++ b/options/auth.go
@@ -20,6 +20,14 @@ func WithPassword(s string) Option {
 	}
 }
 
+func WithPrivateKey(s string) Option {
+	return func(o *scrapligointernal.Options) error {
+		o.Auth.PrivateKey = s
+
+		return nil
+	}
+}
+
 // WithPrivateKeyPath sets the private key to use for authentication to the target device.
 func WithPrivateKeyPath(s string) Option {
 	return func(o *scrapligointernal.Options) error {

--- a/options/transport_bin.go
+++ b/options/transport_bin.go
@@ -42,8 +42,14 @@ func WithBinTransportSSHConfigFile(s string) Option {
 	}
 }
 
-// WithBinTransportKnownHostsFile sets the known hosts file to use (via -o UserKnownHostsFile)
-// for the command.
+func WithBinTransportKnownHosts(s string) Option {
+	return func(o *scrapligointernal.Options) error {
+		o.Transport.Bin.KnownHosts = s
+
+		return nil
+	}
+}
+
 func WithBinTransportKnownHostsFile(s string) Option {
 	return func(o *scrapligointernal.Options) error {
 		o.Transport.Bin.KnownHostsPath = s

--- a/options/transport_ssh2.go
+++ b/options/transport_ssh2.go
@@ -2,7 +2,14 @@ package options
 
 import scrapligointernal "github.com/scrapli/scrapligo/v2/internal"
 
-// WithSSH2KnownHostsPath sets the known hosts file to use with libssh2 connections.
+func WithSSH2KnownHosts(s string) Option {
+	return func(o *scrapligointernal.Options) error {
+		o.Transport.SSH2.KnownHosts = s
+
+		return nil
+	}
+}
+
 func WithSSH2KnownHostsPath(s string) Option {
 	return func(o *scrapligointernal.Options) error {
 		o.Transport.SSH2.KnownHostsPath = s


### PR DESCRIPTION
## Summary

Companion PR to [scrapli/libscrapli#18](https://github.com/scrapli/libscrapli/pull/18) — exposes the new in-memory SSH authentication and known hosts options through the Go API.

- **`WithPrivateKey(s string)`** — authenticate with a PEM/OpenSSH private key passed as a string, without writing it to disk. Complements the existing `WithPrivateKeyPath`.
- **`WithSSH2KnownHosts(s string)`** / **`WithBinTransportKnownHosts(s string)`** — provide known hosts content directly in memory for host key verification, without needing a file. Complements the existing path-based options.
- FFI struct fields (`privateKey`/`privateKeyLen`, `knownHosts`/`knownHostsLen`) added to match the updated libscrapli C ABI.

## Motivation

In ephemeral or locked-down environments (containers, CI, serverless, vault-backed secrets), writing SSH keys and known_hosts files to the filesystem is awkward or impossible. Accepting these values as in-memory strings removes that friction while keeping the existing file-path options fully backward compatible.

## Changes

| File | What changed |
|---|---|
| `options/auth.go` | New `WithPrivateKey` functional option |
| `options/transport_ssh2.go` | New `WithSSH2KnownHosts` functional option |
| `options/transport_bin.go` | New `WithBinTransportKnownHosts` functional option |
| `internal/options.go` | `PrivateKey`, `KnownHosts` fields + apply logic on `AuthOptions`, `TransportBinOptions`, `TransportSSH2Options` |
| `internal/ffi.go` | FFI struct fields: `privateKey`/`Len`, `knownHosts`/`Len` on auth, bin, and ssh2 structs |

## Dependencies

- Requires [scrapli/libscrapli#18](https://github.com/scrapli/libscrapli/pull/18) to be merged first (or concurrently) for the underlying C implementation.

## Test plan

- [ ] Verify existing file-path-based auth and known hosts options still work
- [ ] Test `WithPrivateKey` with PEM and OpenSSH format key strings
- [ ] Test `WithSSH2KnownHosts` / `WithBinTransportKnownHosts` with known hosts content
- [ ] Confirm FFI struct alignment matches updated libscrapli