### PR TITLE
fix panic after reading from closed channel in system transport

### DIFF
--- a/channel/read.go
+++ b/channel/read.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/scrapli/scrapligo/util"
@@ -66,6 +67,14 @@ func (c *Channel) read() {
 				// the underlying transport was closed so just return, we *probably* will have
 				// already bailed out by reading from the (maybe/probably) closed done channel, but
 				// if we hit EOF we know we are done anyway
+				return
+			}
+
+			if strings.Contains(err.Error(), "input/output error") {
+				// on Linux (including containerized environments) closing a PTY master fd
+				// returns EIO ("input/output error") rather than io.EOF -- this is a known
+				// kernel behavior documented in the system transport tests. treat it the same
+				// as EOF: the underlying transport is gone and we are done
 				return
 			}
 


### PR DESCRIPTION
Hello! 

When using the system transport on Linux (including containerized environments like Alpine/Docker), closing the connection could cause a panic:

panic: send on closed channel

goroutine N [running]:
github.com/scrapli/scrapligo/channel.(*Channel).read(...)
    channel/read.go:80

Root cause
The read() loop already handles io.EOF as a terminal condition — returning cleanly without touching c.Errs. However, on Linux, reading from a PTY master fd after the slave side closes (i.e. the ssh process exits) does not return io.EOF. Instead, the kernel returns EIO ("input/output error"), because PTY semantics model a physical terminal disconnect, not a regular pipe end-of-stream (as I understand)

This is actually already documented in transport/system_test.go:
if strings.Contains(readErr.Error(), "input/output error") {
    // in ci for whatever reason we get a "/dev/ptmx input/output error" rather
    // than EOF ...
    return
}
The test handles it at the transport level, but channel/read.go only checked for io.EOF, so EIO fell through to c.Errs <- err — which panics if Close() has already run close(c.Errs).

Fix
Treat "input/output error" the same way as io.EOF in the channel read loop — the transport is gone and there's nothing left to do.

