### PR TITLE
Support for libscrapli in-memory private key authentication

### DIFF
--- a/constants/versions.go
+++ b/constants/versions.go
@@ -5,7 +5,7 @@ var Version = "0.0.0"
 
 // LibScrapliVersion is the version of libscrapli scrapligo was built with. Should be set prior to
 // a release via build/update_all.sh to the version of libscrapli bundled in assets.
-var LibScrapliVersion = "0.0.1-rc.3"
+var LibScrapliVersion = "0.0.0"
 
 // ScrapliDefinitionsVersion is the version of scrapli definitions embedded in assets in this build.
 // This should be set prior to a release via build/update_all.sh.

--- a/constants/versions.go
+++ b/constants/versions.go
@@ -5,8 +5,8 @@ var Version = "0.0.0"
 
 // LibScrapliVersion is the version of libscrapli scrapligo was built with. Should be set prior to
 // a release via build/update_all.sh to the version of libscrapli bundled in assets.
-var LibScrapliVersion = "0.0.0"
+var LibScrapliVersion = "0.0.1-rc.4"
 
 // ScrapliDefinitionsVersion is the version of scrapli definitions embedded in assets in this build.
 // This should be set prior to a release via build/update_all.sh.
-var ScrapliDefinitionsVersion = "0.0.3"
+var ScrapliDefinitionsVersion = "0.0.4"

--- a/internal/ffi.go
+++ b/internal/ffi.go
@@ -45,6 +45,8 @@ type driverOptions struct {
 		privateKeyPathLen       uintptr
 		privateKeyPassphrase    uintptr
 		privateKeyPassphraseLen uintptr
+		privateKeyContent       uintptr
+		privateKeyContentLen    uintptr
 		lookups                 struct {
 			keys     uintptr
 			keysLens uintptr

--- a/internal/options.go
+++ b/internal/options.go
@@ -201,6 +201,7 @@ type AuthOptions struct {
 
 	PrivateKeyPath       string
 	PrivateKeyPassphrase string
+	PrivateKeyContent    string
 
 	LookupMap        map[string]string
 	lookupMapKeys    []string
@@ -235,6 +236,11 @@ func (o *AuthOptions) apply(opts *driverOptions) {
 	if o.PrivateKeyPassphrase != "" {
 		opts.auth.privateKeyPassphrase = uintptr(unsafe.Pointer(&[]byte(o.PrivateKeyPassphrase)[0]))
 		opts.auth.privateKeyPassphraseLen = uintptr(len(o.PrivateKeyPassphrase))
+	}
+
+	if o.PrivateKeyContent != "" {
+		opts.auth.privateKeyContent = uintptr(unsafe.Pointer(&[]byte(o.PrivateKeyContent)[0]))
+		opts.auth.privateKeyContentLen = uintptr(len(o.PrivateKeyContent))
 	}
 
 	if len(o.LookupMap) > 0 {

--- a/options/auth.go
+++ b/options/auth.go
@@ -39,6 +39,16 @@ func WithPrivateKeyPassphrase(s string) Option {
 	}
 }
 
+// WithPrivateKeyContent sets the PEM-encoded private key content to use for authentication to the
+// target device. When set, this takes priority over WithPrivateKeyPath.
+func WithPrivateKeyContent(s string) Option {
+	return func(o *scrapligointernal.Options) error {
+		o.Auth.PrivateKeyContent = s
+
+		return nil
+	}
+}
+
 // WithLookupKeyValue adds an entry to the lookup map for the driver instance.
 func WithLookupKeyValue(key, value string) Option {
 	return func(o *scrapligointernal.Options) error {


### PR DESCRIPTION
## Description

This PR adds support for authenticating with a private key provided directly in memory, without requiring a key file on disk. 

> [!NOTE] 
> https://github.com/scrapli/libscrapli/pull/20 needs to be merged before this PR should be reviewed and merged.

### Relevant PRs
- https://github.com/scrapli/libscrapli/pull/20

## Purpose

Our integration manages credentials in memory and should never write private keys to disk. This change enables that workflow removing disk exposure for key material during auth.

## Testing

Built with locally updated compatible scrapligo binaries and ensured consistent behavior within our implementation and test bench with in-memory auth keys.