### PR TITLE
fix: cancellation cleanup for ffi operations

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
+	"time"
 
 	scrapligoassets "github.com/scrapli/scrapligo/v2/assets"
 	scrapligoclidefinitionoptions "github.com/scrapli/scrapligo/v2/cli/definitionoptions"
@@ -17,8 +17,13 @@ import (
 	scrapligointernal "github.com/scrapli/scrapligo/v2/internal"
 	scrapligologging "github.com/scrapli/scrapligo/v2/logging"
 	scrapligooptions "github.com/scrapli/scrapligo/v2/options"
+	scrapligoutil "github.com/scrapli/scrapligo/v2/util"
 	"golang.org/x/sys/unix"
 )
+
+const defaultCancelCleanupGrace = 5 * time.Second
+
+var errOperationCancelCleanupTimeout = errors.New("libscrapli operation cleanup timeout")
 
 func loadDefinition(o *scrapligointernal.Options) error {
 	definitionFileOrNameString := o.Cli.DefinitionFileOrName
@@ -188,14 +193,16 @@ func (c *Cli) GetOptions() (string, error) {
 func (c *Cli) Open(ctx context.Context) (*Result, error) {
 	// ensure we dealloc if something happens, otherwise users calls to defer close would not be
 	// super handy
-	cleanup := false
+	cleanup, cleanupFree := false, true
 
 	defer func() {
 		if !cleanup {
 			return
 		}
 
-		c.ffiMap.Shared.Free(c.ptr)
+		if cleanupFree {
+			c.ffiMap.Shared.Free(c.ptr)
+		}
 
 		c.ptr = 0
 	}()
@@ -235,6 +242,7 @@ func (c *Cli) Open(ctx context.Context) (*Result, error) {
 	result, err := c.getResult(ctx, &cancel, operationID)
 	if err != nil {
 		cleanup = true
+		cleanupFree = !errors.Is(err, errOperationCancelCleanupTimeout)
 
 		return nil, err
 	}
@@ -248,8 +256,12 @@ func (c *Cli) Close(ctx context.Context) (*Result, error) {
 		return nil, scrapligoerrors.NewFfiError("driver pointer nil", nil)
 	}
 
+	cleanup := true
+
 	defer func() {
-		c.ffiMap.Shared.Free(c.ptr)
+		if cleanup {
+			c.ffiMap.Shared.Free(c.ptr)
+		}
 
 		c.ptr = 0
 	}()
@@ -263,7 +275,14 @@ func (c *Cli) Close(ctx context.Context) (*Result, error) {
 		return nil, err
 	}
 
-	return c.getResult(ctx, &cancel, operationID)
+	result, err := c.getResult(ctx, &cancel, operationID)
+	if err != nil {
+		cleanup = !errors.Is(err, errOperationCancelCleanupTimeout)
+
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // ReplaceDefinition replaces the "definition" of the driver. Most importantly changes/updates
@@ -288,43 +307,30 @@ func (c *Cli) getResult( //nolint: funlen,gocyclo
 	cancel *bool,
 	operationID uint32,
 ) (*Result, error) {
-	done := make(chan struct{}, 1)
-	defer close(done)
-
 	var operationCount uint32
 
-	cancelLock := &sync.Mutex{}
-
-	// so in go flavor we actually use ctx to cause libscrapli to timeout vs python where we rely on
-	// the timeouts in libscrapli itself. so in this case we need to ensure that we do not block the
-	// context so it can properly cancel on timeout/cancellation...
-	go func() {
-		select {
-		case <-ctx.Done():
-			cancelLock.Lock()
-			defer cancelLock.Unlock()
-
-			*cancel = true
-
-			return
-		case <-done:
-			return
-		}
-	}()
-
 	var n int
+	var ctxErr error
+	var cancelCleanupDeadline time.Time
 
 	pollFds := []unix.PollFd{{Fd: int32(c.pollFd), Events: unix.POLLIN}} //nolint: gosec
 
 	for {
-		if ctx.Err() != nil {
-			cancelLock.Lock()
-
+		if ctxErr == nil && ctx.Err() != nil {
+			ctxErr = ctx.Err()
 			*cancel = true
 
-			cancelLock.Unlock()
+			cancelCleanupDeadline = time.Now().Add(c.cancelCleanupGrace())
+		}
 
-			return nil, ctx.Err()
+		if ctxErr != nil && time.Now().After(cancelCleanupDeadline) {
+			msg := "libscrapli operation did not finish after cancellation; " +
+				"skipping free to avoid blocking in FFI cleanup"
+
+			return nil, scrapligoerrors.NewFfiError(
+				msg,
+				errors.Join(ctxErr, errOperationCancelCleanupTimeout),
+			)
 		}
 
 		pollFds[0].Revents = 0
@@ -438,6 +444,10 @@ func (c *Cli) getResult( //nolint: funlen,gocyclo
 		return nil, scrapligoerrors.NewFfiError(outErrMsg, ctx.Err())
 	}
 
+	if ctxErr != nil {
+		return nil, ctxErr
+	}
+
 	return NewResult(
 		c.host,
 		c.options.Port,
@@ -448,4 +458,17 @@ func (c *Cli) getResult( //nolint: funlen,gocyclo
 		results,
 		resultsFailedWhenIndicator,
 	), nil
+}
+
+func (c *Cli) cancelCleanupGrace() time.Duration {
+	if c.options == nil || c.options.Session.OperationTimeoutNs == nil {
+		return defaultCancelCleanupGrace
+	}
+
+	v := *c.options.Session.OperationTimeoutNs
+	if v == 0 {
+		return defaultCancelCleanupGrace
+	}
+
+	return time.Duration(scrapligoutil.SafeUint64ToInt64(v))
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -310,7 +310,9 @@ func (c *Cli) getResult( //nolint: funlen,gocyclo
 	var operationCount uint32
 
 	var n int
+
 	var ctxErr error
+
 	var cancelCleanupDeadline time.Time
 
 	pollFds := []unix.PollFd{{Fd: int32(c.pollFd), Events: unix.POLLIN}} //nolint: gosec

--- a/netconf/netconf.go
+++ b/netconf/netconf.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
+	"time"
 
 	scrapligoconstants "github.com/scrapli/scrapligo/v2/constants"
 	scrapligoerrors "github.com/scrapli/scrapligo/v2/errors"
@@ -12,8 +12,13 @@ import (
 	scrapligointernal "github.com/scrapli/scrapligo/v2/internal"
 	scrapligologging "github.com/scrapli/scrapligo/v2/logging"
 	scrapligooptions "github.com/scrapli/scrapligo/v2/options"
+	scrapligoutil "github.com/scrapli/scrapligo/v2/util"
 	"golang.org/x/sys/unix"
 )
+
+const defaultCancelCleanupGrace = 5 * time.Second
+
+var errOperationCancelCleanupTimeout = errors.New("libscrapli operation cleanup timeout")
 
 func newCloseOptions(options ...Option) *closeOptions {
 	o := &closeOptions{}
@@ -116,14 +121,16 @@ func (n *Netconf) GetOptions() (string, error) {
 func (n *Netconf) Open(ctx context.Context) (*Result, error) {
 	// ensure we dealloc if something happens, otherwise users calls to defer close would not be
 	// super handy
-	cleanup := false
+	cleanup, cleanupFree := false, true
 
 	defer func() {
 		if !cleanup {
 			return
 		}
 
-		n.ffiMap.Shared.Free(n.ptr)
+		if cleanupFree {
+			n.ffiMap.Shared.Free(n.ptr)
+		}
 
 		n.ptr = 0
 	}()
@@ -163,6 +170,7 @@ func (n *Netconf) Open(ctx context.Context) (*Result, error) {
 	result, err := n.getResult(ctx, &cancel, operationID)
 	if err != nil {
 		cleanup = true
+		cleanupFree = !errors.Is(err, errOperationCancelCleanupTimeout)
 
 		return nil, err
 	}
@@ -176,8 +184,12 @@ func (n *Netconf) Close(ctx context.Context, options ...Option) (*Result, error)
 		return nil, scrapligoerrors.NewFfiError("driver pointer nil", nil)
 	}
 
+	cleanup := true
+
 	defer func() {
-		n.ffiMap.Shared.Free(n.ptr)
+		if cleanup {
+			n.ffiMap.Shared.Free(n.ptr)
+		}
 
 		n.ptr = 0
 	}()
@@ -193,7 +205,14 @@ func (n *Netconf) Close(ctx context.Context, options ...Option) (*Result, error)
 		return nil, err
 	}
 
-	return n.getResult(ctx, &cancel, operationID)
+	result, err := n.getResult(ctx, &cancel, operationID)
+	if err != nil {
+		cleanup = !errors.Is(err, errOperationCancelCleanupTimeout)
+
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // GetSessionID returns the session-id as parsed during the capabilities exchange -- if we for some
@@ -300,38 +319,28 @@ func (n *Netconf) getResult( //nolint: funlen,gocyclo
 	cancel *bool,
 	operationID uint32,
 ) (*Result, error) {
-	done := make(chan struct{}, 1)
-	defer close(done)
-
-	cancelLock := &sync.Mutex{}
-
-	go func() {
-		select {
-		case <-ctx.Done():
-			cancelLock.Lock()
-			defer cancelLock.Unlock()
-
-			*cancel = true
-
-			return
-		case <-done:
-			return
-		}
-	}()
-
 	var _n int
+	var ctxErr error
+	var cancelCleanupDeadline time.Time
 
 	pollFds := []unix.PollFd{{Fd: int32(n.pollFd), Events: unix.POLLIN}} //nolint: gosec
 
 	for {
-		if ctx.Err() != nil {
-			cancelLock.Lock()
-
+		if ctxErr == nil && ctx.Err() != nil {
+			ctxErr = ctx.Err()
 			*cancel = true
 
-			cancelLock.Unlock()
+			cancelCleanupDeadline = time.Now().Add(n.cancelCleanupGrace())
+		}
 
-			return nil, ctx.Err()
+		if ctxErr != nil && time.Now().After(cancelCleanupDeadline) {
+			msg := "libscrapli operation did not finish after cancellation; " +
+				"skipping free to avoid blocking in FFI cleanup"
+
+			return nil, scrapligoerrors.NewFfiError(
+				msg,
+				errors.Join(ctxErr, errOperationCancelCleanupTimeout),
+			)
 		}
 
 		pollFds[0].Revents = 0
@@ -445,6 +454,10 @@ func (n *Netconf) getResult( //nolint: funlen,gocyclo
 		return nil, scrapligoerrors.NewFfiError(outErrMsg, ctx.Err())
 	}
 
+	if ctxErr != nil {
+		return nil, ctxErr
+	}
+
 	return NewResult(
 		string(input),
 		n.host,
@@ -456,4 +469,17 @@ func (n *Netconf) getResult( //nolint: funlen,gocyclo
 		rpcWarnings,
 		rpcErrors,
 	), nil
+}
+
+func (n *Netconf) cancelCleanupGrace() time.Duration {
+	if n.options == nil || n.options.Session.OperationTimeoutNs == nil {
+		return defaultCancelCleanupGrace
+	}
+
+	v := *n.options.Session.OperationTimeoutNs
+	if v == 0 {
+		return defaultCancelCleanupGrace
+	}
+
+	return time.Duration(scrapligoutil.SafeUint64ToInt64(v))
 }

--- a/netconf/netconf.go
+++ b/netconf/netconf.go
@@ -320,7 +320,9 @@ func (n *Netconf) getResult( //nolint: funlen,gocyclo
 	operationID uint32,
 ) (*Result, error) {
 	var _n int
+
 	var ctxErr error
+
 	var cancelCleanupDeadline time.Time
 
 	pollFds := []unix.PollFd{{Fd: int32(n.pollFd), Events: unix.POLLIN}} //nolint: gosec


### PR DESCRIPTION
This is the second part of a hunt for race condition hang forever bug I've been chasing. The other part is this PR in libscrapli: https://github.com/scrapli/libscrapli/pull/30 
# Fix Cancellation Cleanup for FFI Operations

## Summary

This changes CLI and Netconf operation cancellation handling so that a Go context timeout does not immediately trigger libscrapli driver cleanup while the native operation may still be active.

When a context is cancelled, scrapligo now sets the libscrapli cancellation flag and waits for the operation to finish for a bounded cleanup grace period. If libscrapli completes during that grace period, scrapligo fetches the operation result/error normally. If libscrapli does not finish, scrapligo returns a cleanup-timeout error and skips `Shared.Free` to avoid blocking the Go goroutine indefinitely inside an FFI call.

The change is applied to both:

- `cli.Cli`
- `netconf.Netconf`

## Problem

Previously, `getResult` returned immediately when `ctx.Err()` became non-nil:

```go
if ctx.Err() != nil {
    *cancel = true
    return nil, ctx.Err()
}
```

That treated Go context cancellation as if the libscrapli operation had already completed. In reality, setting `*cancel = true` only asks libscrapli to cancel. The operation thread may still be running.

For `Open` and `Close`, returning immediately can run deferred cleanup that calls:

```go
c.ffiMap.Shared.Free(c.ptr)
```

If libscrapli is still executing the operation, `Shared.Free` can block indefinitely while waiting for native cleanup or operation-thread shutdown.

## Fix

- Preserve the original context error when cancellation is observed.
- Set the libscrapli cancellation flag (`*cancel = true`).
- Continue polling the libscrapli operation-ready fd for a bounded cleanup grace period.
- If libscrapli completes, fetch the operation result normally and return the libscrapli/context error as appropriate.
- If the cleanup grace period expires, return a `libscrapli operation cleanup timeout` error.
- In `Open` and `Close`, skip `Shared.Free` only for that cleanup-timeout case.
- Still clear the Go-side driver pointer so callers cannot reuse a potentially unsafe native handle.

## Residual Risk

If libscrapli never finishes after cancellation, the native driver may leak because scrapligo intentionally skips `Shared.Free` on cleanup-timeout.

This is an explicit tradeoff: leaking the native driver is preferable to wedging the Go goroutine forever inside `Shared.Free`, where Go cannot interrupt the blocking FFI call.

## Validation

Targeted package tests pass:

```bash
go test ./cli ./netconf
```

Full `go test ./...` was also run, but e2e packages failed because the external lab services were unavailable (`connection refused` / unable to resolve host). The non-e2e packages, including the touched `cli` and `netconf` packages, passed.

## Notes

This patch does not change public APIs. It only changes internal cancellation cleanup behavior around libscrapli operation completion and native driver cleanup.
