### PR TITLE
fix: correct netconf 1.1 chunk framing (RFC 6242)

### DIFF
--- a/driver/netconf/message.go
+++ b/driver/netconf/message.go
@@ -46,7 +46,10 @@ func (m *message) serialize(
 	case V1Dot0:
 		msg = append(msg, []byte(v1Dot0Delim)...)
 	case V1Dot1:
-		msg = append([]byte(fmt.Sprintf("#%d\n", len(msg))), msg...)
+		// per RFC 6242 a chunk must start with its own leading LF ("chunk = LF chunk-size LF
+		// chunk-data") -- make the framed message fully self contained rather than relying on
+		// a neighboring message's trailing newline to (sometimes) supply it.
+		msg = append([]byte(fmt.Sprintf("\n#%d\n", len(msg))), msg...)
 		msg = append(msg, []byte("\n##")...)
 	}
 

--- a/driver/netconf/rpc.go
+++ b/driver/netconf/rpc.go
@@ -50,16 +50,14 @@ func (d *Driver) sendRPC(
 		d.SelectedVersion,
 	)
 
+	// WriteAndReturn already appends the trailing "\n" that terminates the v1.1 "\n##\n"
+	// end-of-chunks marker (and, for v1.0, follows the "]]>]]>" delimiter). Writing an
+	// additional return here (as was previously done for v1.1) sends a spurious extra "\n"
+	// that some strict NETCONF servers reject with a framing error, e.g. "invalid protocol
+	// framing characters received".
 	err = d.Channel.WriteAndReturn(serialized.framedXML, false)
 	if err != nil {
 		return nil, err
-	}
-
-	if d.SelectedVersion == V1Dot1 {
-		err = d.Channel.WriteReturn()
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	done := make(chan []byte)

--- a/driver/netconf/test-fixtures/golden/commit-discard-simple-in.txt
+++ b/driver/netconf/test-fixtures/golden/commit-discard-simple-in.txt
@@ -6,16 +6,14 @@
 </hello>]]>]]>
 
 
+
 #131
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><commit></commit></rpc>
 ##
 
 
 
-
 #149
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102"><discard-changes></discard-changes></rpc>
 ##
-
-
 

--- a/driver/netconf/test-fixtures/golden/copy-config-simple-in.txt
+++ b/driver/netconf/test-fixtures/golden/copy-config-simple-in.txt
@@ -6,9 +6,8 @@
 </hello>]]>]]>
 
 
+
 #213
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><copy-config><target><running></running></target><source><running></running></source></copy-config></rpc>
 ##
-
-
 

--- a/driver/netconf/test-fixtures/golden/delete-config-simple-in.txt
+++ b/driver/netconf/test-fixtures/golden/delete-config-simple-in.txt
@@ -6,9 +6,8 @@
 </hello>]]>]]>
 
 
+
 #181
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><delete-config><target><startup></startup></target></delete-config></rpc>
 ##
-
-
 

--- a/driver/netconf/test-fixtures/golden/edit-config-simple-in.txt
+++ b/driver/netconf/test-fixtures/golden/edit-config-simple-in.txt
@@ -6,6 +6,7 @@
 </hello>]]>]]>
 
 
+
 #453
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><edit-config><target><candidate></candidate></target><config>
     <cdp xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-cdp-cfg">
@@ -17,6 +18,4 @@
     </cdp>
 </config></edit-config></rpc>
 ##
-
-
 

--- a/driver/netconf/test-fixtures/golden/get-simple-in.txt
+++ b/driver/netconf/test-fixtures/golden/get-simple-in.txt
@@ -6,10 +6,9 @@
 </hello>]]>]]>
 
 
+
 #249
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><get><filter type="subtree"><netconf-yang xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-cfg">
 </netconf-yang></filter></get></rpc>
 ##
-
-
 

--- a/driver/netconf/test-fixtures/golden/getconfig-simple-in.txt
+++ b/driver/netconf/test-fixtures/golden/getconfig-simple-in.txt
@@ -6,9 +6,8 @@
 </hello>]]>]]>
 
 
+
 #175
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><get-config><source><running></running></source></get-config></rpc>
 ##
-
-
 

--- a/driver/netconf/test-fixtures/golden/lock-unlock-simple-in.txt
+++ b/driver/netconf/test-fixtures/golden/lock-unlock-simple-in.txt
@@ -6,16 +6,14 @@
 </hello>]]>]]>
 
 
+
 #163
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><lock><target><running></running></target></lock></rpc>
 ##
 
 
 
-
 #167
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="102"><unlock><target><running></running></target></unlock></rpc>
 ##
-
-
 

--- a/driver/netconf/test-fixtures/golden/validate-simple-in.txt
+++ b/driver/netconf/test-fixtures/golden/validate-simple-in.txt
@@ -6,9 +6,8 @@
 </hello>]]>]]>
 
 
+
 #175
 <?xml version="1.0" encoding="UTF-8"?><rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101"><validate><source><candidate></candidate></source></validate></rpc>
 ##
-
-
 


### PR DESCRIPTION
## Summary

`sendRPC` framed netconf 1.1 (chunked) rpc messages incorrectly:

- `message.serialize()` built the chunk body as `#<len>\n<data>\n##`, missing the leading `LF` a chunk requires per RFC 6242 (`chunk = LF chunk-size LF chunk-data`). It relied on a *neighboring* message's trailing newline to (sometimes) supply that leading `LF` instead of being self-contained.
- That assumption breaks for the very first rpc sent after the hello exchange, since hello is always framed with the `]]>]]>` delimiter regardless of the negotiated version, so its trailing newline isn't a reliable substitute once the server switches into strict chunked-framing mode.
- On top of that, `sendRPC` wrote an extra, redundant `WriteReturn()` after every v1.1 message, in addition to the trailing newline `WriteAndReturn` already appends.

Together these produced non-compliant framing that strict NETCONF 1.1 servers reject, e.g.:

```
invalid protocol framing characters received
```

I hit this running `GetConfig("running")` against a real IP Infusion OcNOS device that negotiates NETCONF 1.1 by default -- the very first rpc after the hello exchange failed every time.

## Changes

- `driver/netconf/message.go`: `serialize()` now prepends the chunk's own leading `"\n"` so every framed v1.1 message is fully self-contained instead of borrowing bytes from whatever was sent before it.
- `driver/netconf/rpc.go`: removed the extra, redundant `WriteReturn()` call for the v1.1 case.
- Updated the recorded golden fixtures under `driver/netconf/test-fixtures` to match the corrected (RFC-compliant) wire output.

## Test plan

- [x] `go test -race ./driver/netconf/...` -- passes, golden fixtures regenerated and reviewed (only the previously-incorrect blank lines around chunk headers changed)
- [x] `go test -race ./channel/...` -- passes
- [x] Verified end-to-end against a real IP Infusion OcNOS device: `GetConfig("running")` over a NETCONF 1.1 session (the server's default/preferred version) now succeeds where it previously failed on the very first rpc

Made with [Cursor](https://cursor.com)